### PR TITLE
Due date bugfix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+## 1.0.1 Unreleased
+ * The RTAC "dueDate" field was incorrectly being set to the current date/time
+   in the case where "dueDate" was not set in the FOLIO loan. In this case,
+   RTAC should not set the "dueDate" in the response.
+ * Updated RMB dependency to 19.1.3.
+
 ## 1.0.0 2018-05-18
  * POM file cleanup
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <http.port>8081</http.port>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
-    <raml-module-builder.version>19.0.0</raml-module-builder.version>
+    <raml-module-builder.version>19.1.3</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <postgres.driver.version>9.4.1212</postgres.driver.version>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>3.5.0</version>
+      <version>3.5.1</version>
       <scope>test</scope>
     </dependency>
 
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>3.0.7</version>
+      <version>3.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/folio/rest/impl/RTACResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/RTACResourceImpl.java
@@ -1,6 +1,5 @@
 package org.folio.rest.impl;
 
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -21,6 +20,7 @@ import org.folio.rest.tools.client.Response;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.rtac.rest.exceptions.HttpException;
+import org.joda.time.DateTime;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
@@ -204,7 +204,7 @@ public final class RTACResourceImpl implements RTACResource {
       try {
         final String dueDateString = responseBody.getJsonArray("loans").getJsonObject(0).getString("dueDate");
         if (dueDateString != null) {
-          dueDate = Date.from(ZonedDateTime.parse(dueDateString).toInstant());
+          dueDate = new DateTime(dueDateString).toDate();
         }
       } catch (Exception e) {
         log.error("Unable to extract the loan dueDate", e);

--- a/src/main/java/org/folio/rest/impl/RTACResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/RTACResourceImpl.java
@@ -1,5 +1,6 @@
 package org.folio.rest.impl;
 
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -20,7 +21,6 @@ import org.folio.rest.tools.client.Response;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.rtac.rest.exceptions.HttpException;
-import org.joda.time.DateTime;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
@@ -202,7 +202,10 @@ public final class RTACResourceImpl implements RTACResource {
       }
       Date dueDate = null;
       try {
-        dueDate = new DateTime(responseBody.getJsonArray("loans").getJsonObject(0).getString("dueDate")).toDate();
+        final String dueDateString = responseBody.getJsonArray("loans").getJsonObject(0).getString("dueDate");
+        if (dueDateString != null) {
+          dueDate = Date.from(ZonedDateTime.parse(dueDateString).toInstant());
+        }
       } catch (Exception e) {
         log.error("Unable to extract the loan dueDate", e);
       }

--- a/src/test/java/org/folio/rest/impl/RTACResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/RTACResourceImplTest.java
@@ -85,6 +85,11 @@ public class RTACResourceImplTest {
           .setStatusCode(200)
           .putHeader("content-type", "application/json")
           .end(readMockFile("RTACResourceImpl/success_instance_3.json"));
+      } else if (req.path().equals(String.format("/inventory/instances/%s", "0085f8ed-80ba-435b-8734-d3262aa4fc07"))) {
+        req.response()
+          .setStatusCode(200)
+          .putHeader("content-type", "application/json")
+          .end(readMockFile("RTACResourceImpl/success_instance_4.json"));
       } else if (req.path().equals("/holdings-storage/holdings")) {
         if (req.query().equals(String.format("limit=100&query=instanceId%%3D%%3D%s", "76d5a72a-af24-4ac6-8e73-4e39604f6f59"))) {
           req.response()
@@ -101,6 +106,11 @@ public class RTACResourceImplTest {
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
             .end(readMockFile("RTACResourceImpl/success_holdings_2.json"));
+        } else if (req.query().equals(String.format("limit=100&query=instanceId%%3D%%3D%s", "0085f8ed-80ba-435b-8734-d3262aa4fc07"))) {
+          req.response()
+            .setStatusCode(200)
+            .putHeader("content-type", "application/json")
+            .end(readMockFile("RTACResourceImpl/success_holdings_3.json"));
         } else {
           req.response().setStatusCode(500).end("Unexpected call: " + req.path());
         }
@@ -120,6 +130,11 @@ public class RTACResourceImplTest {
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
             .end(readMockFile("RTACResourceImpl/success_items_3.json"));
+        } else if (req.query().equals(String.format("limit=100&query=holdingsRecordId%%3D%%3D%s", "aa3487a4-af65-4285-939c-05601b98827c"))) {
+          req.response()
+            .setStatusCode(200)
+            .putHeader("content-type", "application/json")
+            .end(readMockFile("RTACResourceImpl/success_items_4.json"));
         } else {
           req.response().setStatusCode(500).end("Unexpected call: " + req.path());
         }
@@ -149,6 +164,11 @@ public class RTACResourceImplTest {
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
             .end(readMockFile("RTACResourceImpl/success_loans_5.json"));
+        } else if (req.query().equals(String.format("limit=100&query=%%28itemId%%3D%%3D%s%%20and%%20status.name%%3D%%3DOpen%%29", "53462dc6-55aa-4b99-8717-6ae8bbef5331"))) {
+          req.response()
+            .setStatusCode(200)
+            .putHeader("content-type", "application/json")
+            .end(readMockFile("RTACResourceImpl/success_loans_6.json"));
         } else {
           req.response().setStatusCode(500).end("Unexpected call: " + req.path());
         }
@@ -195,6 +215,55 @@ public class RTACResourceImplTest {
 
       boolean found = false;
       for (int j = 0; j < 5; j++) {
+        final JsonObject expectedJO = expectedJson.getJsonArray("holdings").getJsonObject(j);
+        if (id.equals(expectedJO.getString("id"))) {
+          found = true;
+          context.assertEquals(expectedJO.getString("location"), jo.getString("location"));
+          context.assertEquals(expectedJO.getString("callNumber"), jo.getString("callNumber"));
+          context.assertEquals(expectedJO.getString("status"), jo.getString("status"));
+          context.assertEquals(expectedJO.getString("dueDate"), jo.getString("dueDate"));
+          context.assertEquals(expectedJO.getString("tempLocation"), jo.getString("tempLocation"));
+          break;
+        }
+      }
+
+      if (found == false) {
+        context.fail("Unexpected id: " + id);
+      }
+    }
+
+    asyncLocal.complete();
+
+    // Test done
+    logger.info("Test done");
+  }
+
+  @Test
+  public final void testGetRtacByIdNoDueDate(TestContext context) {
+    logger.info("Testing for successful RTAC by instance id");
+    final Async asyncLocal = context.async();
+
+    final Response r = RestAssured
+      .given()
+        .header(tenantHeader)
+        .header(urlHeader)
+        .header(contentTypeHeader)
+      .get("/rtac/0085f8ed-80ba-435b-8734-d3262aa4fc07")
+        .then()
+          .contentType(ContentType.JSON)
+          .statusCode(200).extract().response();
+
+    final String body = r.getBody().asString();
+    final JsonObject json = new JsonObject(body);
+    final JsonObject expectedJson = new JsonObject(readMockFile("RTACResourceImpl/success_rtac_response_no_dueDate.json"));
+
+    context.assertEquals(1, json.getJsonArray("holdings").size());
+    for (int i = 0; i < 1; i++) {
+      final JsonObject jo = json.getJsonArray("holdings").getJsonObject(i);
+      final String id = jo.getString("id");
+
+      boolean found = false;
+      for (int j = 0; j < 1; j++) {
         final JsonObject expectedJO = expectedJson.getJsonArray("holdings").getJsonObject(j);
         if (id.equals(expectedJO.getString("id"))) {
           found = true;

--- a/src/test/resources/RTACResourceImpl/success_holdings_3.json
+++ b/src/test/resources/RTACResourceImpl/success_holdings_3.json
@@ -1,0 +1,21 @@
+{
+  "holdingsRecords": [
+    {
+      "id": "aa3487a4-af65-4285-939c-05601b98827c",
+      "instanceId": "0085f8ed-80ba-435b-8734-d3262aa4fc07",
+      "permanentLocationId": "b241764c-1466-4e1d-a028-1a3684a5da87",
+      "callNumber": "MCN FICTION",
+      "holdingsStatements": [
+        "Line 1b",
+        "Line 2b"
+      ],
+      "metadata": {
+        "createdDate": "2018-04-13T06:11:49.087+0000",
+        "createdByUserId": "0e3a7a3e-8843-4f43-bcf6-f646839460b6",
+        "updatedDate": "2018-04-13T06:11:49.087+0000",
+        "updatedByUserId": "0e3a7a3e-8843-4f43-bcf6-f646839460b6"
+      }
+    }
+  ],
+  "totalRecords": 1
+}

--- a/src/test/resources/RTACResourceImpl/success_instance_4.json
+++ b/src/test/resources/RTACResourceImpl/success_instance_4.json
@@ -1,0 +1,30 @@
+{
+  "@context": "http://localhost:9130/inventory/instances/context",
+  "id": "0085f8ed-80ba-435b-8734-d3262aa4fc07",
+  "title": "Testing RTAC for Dummies Part 3",
+  "source": "Sample",
+  "instanceTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2c",
+  "identifiers": [
+    {
+      "identifierTypeId": "7f907515-a1bf-4513-8a38-92e1a07c539d",
+      "value": "ABC000002"
+    }
+  ],
+  "contributors": [
+    {
+      "contributorNameTypeId": "2e48e713-17f3-4c13-a9f8-23845bb210aa",
+      "name": "Some Guy",
+      "contributorTypeId": null,
+      "contributorTypeText": null
+    },
+    {
+      "contributorNameTypeId": "e8b311a6-3b21-43f2-a269-dd9310cb2d0a",
+      "name": "Some Other Guy",
+      "contributorTypeId": null,
+      "contributorTypeText": null
+    }
+  ],
+  "links": {
+    "self": "http://localhost:9130/inventory/instances/0085f8ed-80ba-435b-8734-d3262aa4fc07"
+  }
+}

--- a/src/test/resources/RTACResourceImpl/success_items_4.json
+++ b/src/test/resources/RTACResourceImpl/success_items_4.json
@@ -1,0 +1,41 @@
+{
+  "items": [
+    {
+      "id": "53462dc6-55aa-4b99-8717-6ae8bbef5331",
+      "status": {
+        "name": "Checked out"
+      },
+      "title": "Testing RTAC for Dummies",
+      "holdingsRecordId": "aa3487a4-af65-4285-939c-05601b98827c",
+      "barcode": "012345678904",
+      "pieceIdentifiers": [],
+      "notes": [],
+      "materialType": {
+        "id": "5ee11d91-f7e8-481d-b079-65d708582ccc",
+        "name": "dvd"
+      },
+      "permanentLoanType": {
+        "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
+        "name": "Can circulate"
+      },
+      "temporaryLocation": {
+        "id": "2fe4a1ff-fa0f-44e6-8b9a-f93eacf0e8d6",
+        "name": "Demo library"
+      },
+      "metadata": {
+        "createdDate": "2018-04-13T06:11:57.563+0000",
+        "createdByUserId": "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+        "updatedDate": "2018-04-13T06:18:48.317+0000",
+        "updatedByUserId": "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+      },
+      "links": {
+        "self": "http://localhost:9130/inventory/items/53462dc6-55aa-4b99-8717-6ae8bbef5331"
+      },
+      "permanentLocation": {
+        "id": "b241764c-1466-4e1d-a028-1a3684a5da87",
+        "name": "Popular Reading Collection"
+      }
+    }
+  ],
+  "totalRecords": 1
+}

--- a/src/test/resources/RTACResourceImpl/success_loans_6.json
+++ b/src/test/resources/RTACResourceImpl/success_loans_6.json
@@ -1,0 +1,47 @@
+{
+  "loans": [
+    {
+      "id": "10dd7e77-2613-4002-a3bb-4f1fa2de4283",
+      "userId": "6fec4d7a-581d-41bc-a772-0cbd63c631b2",
+      "itemId": "53462dc6-55aa-4b99-8717-6ae8bbef5331",
+      "status": {
+        "name": "Open"
+      },
+      "loanDate": "2018-02-07T08:43:15Z",
+      "action": "checkedout",
+      "renewalCount": 5,
+      "loanPolicyId": "d9cd0bed-1b49-4b5e-a7bd-064b8d177231",
+      "metaData": {
+        "createdDate": "2018-04-13T06:18:48.382+0000",
+        "createdByUserId": "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+        "updatedDate": "2018-04-13T06:18:48.382+0000",
+        "updatedByUserId": "1ad737b0-d847-11e6-bf26-cec0c932ce01"
+      },
+      "item": {
+        "title": "Testing RTAC for Dummies",
+        "contributors": [
+          {
+            "name": "Some Guy"
+          },
+          {
+            "name": "Some Other Guy"
+          }
+        ],
+        "barcode": "012345678905",
+        "holdingsRecordId": "aa3487a4-af65-4285-939c-05601b98827c",
+        "instanceId": "0085f8ed-80ba-435b-8734-d3262aa4fc07",
+        "callNumber": "13579.0",
+        "status": {
+          "name": "Checked out"
+        },
+        "location": {
+          "name": "Media library"
+        },
+        "materialType": {
+          "name": "dvd"
+        }
+      }
+    }
+  ],
+  "totalRecords": 1
+}

--- a/src/test/resources/RTACResourceImpl/success_rtac_response_no_dueDate.json
+++ b/src/test/resources/RTACResourceImpl/success_rtac_response_no_dueDate.json
@@ -1,0 +1,9 @@
+{
+  "holdings" : [ {
+    "id" : "53462dc6-55aa-4b99-8717-6ae8bbef5331",
+    "location" : "Popular Reading Collection",
+    "callNumber" : "MCN FICTION",
+    "status" : "Checked out",
+    "tempLocation" : "Demo library"
+  } ]
+}


### PR DESCRIPTION
The RTAC "dueDate" field was being set regardless of whether or not the field was set in the loan. If "dueDate" was not set in the loan, mod-rtac set it to the current date, due to the field being "null" when extracted from the loan. Now, if "dueDate" is not set in the loan, mod-rtac will not set "dueDate" in the response JSON.