### PR TITLE
Fixes for inventory item "location" changes

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -3,8 +3,8 @@
   "name": "Real Time Availability Check Module",
   "provides": [
     {
-      "id": "${artifactId}",
-      "version": "1.0",
+      "id": "rtac",
+      "version": "1.1",
       "handlers": [
         {
           "methods": ["GET"],
@@ -28,7 +28,7 @@
   "requires": [
     {
       "id": "inventory",
-      "version": "5.2"
+      "version": "5.3"
     },
     {
       "id": "holdings-storage",

--- a/ramls/holding.json
+++ b/ramls/holding.json
@@ -24,10 +24,6 @@
       "type": "string",
       "format": "date-time",
       "description": "The date when the holding will be available"
-    },
-    "tempLocation": {
-      "type": "string",
-      "description": "Temporary location of the holding"
     }
   },
   "required": [

--- a/src/main/java/org/folio/rest/impl/RTACResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/RTACResourceImpl.java
@@ -114,8 +114,7 @@ public final class RTACResourceImpl implements RTACResource {
     holding.setCallNumber(callNumber);
     holding.setId(item.getString("id"));
     holding.setStatus(item.getJsonObject("status", new JsonObject()).getString("name"));
-    holding.setLocation(item.getJsonObject("permanentLocation", new JsonObject()).getString("name"));
-    holding.setTempLocation(item.getJsonObject("temporaryLocation", new JsonObject()).getString("name"));
+    holding.setLocation(item.getJsonObject("effectiveLocation", new JsonObject()).getString("name"));
 
     return holding;
   }

--- a/src/test/java/org/folio/rest/impl/RTACResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/RTACResourceImplTest.java
@@ -222,7 +222,6 @@ public class RTACResourceImplTest {
           context.assertEquals(expectedJO.getString("callNumber"), jo.getString("callNumber"));
           context.assertEquals(expectedJO.getString("status"), jo.getString("status"));
           context.assertEquals(expectedJO.getString("dueDate"), jo.getString("dueDate"));
-          context.assertEquals(expectedJO.getString("tempLocation"), jo.getString("tempLocation"));
           break;
         }
       }
@@ -271,7 +270,6 @@ public class RTACResourceImplTest {
           context.assertEquals(expectedJO.getString("callNumber"), jo.getString("callNumber"));
           context.assertEquals(expectedJO.getString("status"), jo.getString("status"));
           context.assertEquals(expectedJO.getString("dueDate"), jo.getString("dueDate"));
-          context.assertEquals(expectedJO.getString("tempLocation"), jo.getString("tempLocation"));
           break;
         }
       }

--- a/src/test/resources/RTACResourceImpl/success_items_1.json
+++ b/src/test/resources/RTACResourceImpl/success_items_1.json
@@ -18,7 +18,7 @@
 				"id": "2b94c631-fca9-4892-a730-03ee529ffe27",
 				"name": "Can circulate"
 			},
-			"temporaryLocation": {
+			"effectiveLocation": {
 				"id": "53cf956f-c1df-410b-8bea-27f712cca7c0",
 				"name": "Annex"
 			},
@@ -63,7 +63,7 @@
 			"links": {
 				"self": "http://localhost:9130/inventory/items/b116cfe0-b75f-4e12-bdb7-61b08505e164"
 			},
-			"permanentLocation": {
+			"effectiveLocation": {
 				"id": "b241764c-1466-4e1d-a028-1a3684a5da87",
 				"name": "Popular Reading Collection"
 			}
@@ -95,7 +95,7 @@
 			"links": {
 				"self": "http://localhost:9130/inventory/items/a754a5d1-6bd4-4f41-8239-87b7afecccc6"
 			},
-			"permanentLocation": {
+			"effectiveLocation": {
 				"id": "b241764c-1466-4e1d-a028-1a3684a5da87",
 				"name": "Popular Reading Collection"
 			}

--- a/src/test/resources/RTACResourceImpl/success_items_2.json
+++ b/src/test/resources/RTACResourceImpl/success_items_2.json
@@ -18,7 +18,7 @@
 				"id": "2b94c631-fca9-4892-a730-03ee529ffe27",
 				"name": "Can circulate"
 			},
-			"temporaryLocation": {
+			"effectiveLocation": {
 				"id": "2fe4a1ff-fa0f-44e6-8b9a-f93eacf0e8d6",
 				"name": "Demo library"
 			},
@@ -63,7 +63,7 @@
 			"links": {
 				"self": "http://localhost:9130/inventory/items/64a37e8b-1967-4a7e-a20f-d7d2da96e8f6"
 			},
-			"permanentLocation": {
+			"effectiveLocation": {
 				"id": "495f140b-98e7-42c7-b402-8c0724a30aa0",
 				"name": "Media library"
 			}

--- a/src/test/resources/RTACResourceImpl/success_items_4.json
+++ b/src/test/resources/RTACResourceImpl/success_items_4.json
@@ -18,7 +18,7 @@
         "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
         "name": "Can circulate"
       },
-      "temporaryLocation": {
+      "effectiveLocation": {
         "id": "2fe4a1ff-fa0f-44e6-8b9a-f93eacf0e8d6",
         "name": "Demo library"
       },

--- a/src/test/resources/RTACResourceImpl/success_rtac_response.json
+++ b/src/test/resources/RTACResourceImpl/success_rtac_response.json
@@ -1,11 +1,10 @@
 {
   "holdings" : [ {
     "id" : "1a2f476a-436b-4530-82fe-b21a22d55514",
-    "location" : "Popular Reading Collection",
+    "location" : "Annex",
     "callNumber" : "MCN FICTION",
     "status" : "Checked out",
-    "dueDate" : "2017-10-17T08:43:15.000+0000",
-    "tempLocation" : "Annex"
+    "dueDate" : "2017-10-17T08:43:15.000+0000"
   }, {
     "id" : "b116cfe0-b75f-4e12-bdb7-61b08505e164",
     "location" : "Popular Reading Collection",
@@ -19,11 +18,10 @@
     "status" : "Available"
   }, {
     "id" : "650559de-a159-4620-a923-11f38cfcdb87",
-    "location" : "Popular Reading Collection",
+    "location" : "Demo library",
     "callNumber" : "13579.0",
     "status" : "Checked out",
-    "dueDate" : "2018-02-27T08:43:15.000+0000",
-    "tempLocation" : "Demo library"
+    "dueDate" : "2018-02-27T08:43:15.000+0000"
   }, {
     "id" : "64a37e8b-1967-4a7e-a20f-d7d2da96e8f6",
     "location" : "Media library",

--- a/src/test/resources/RTACResourceImpl/success_rtac_response_no_dueDate.json
+++ b/src/test/resources/RTACResourceImpl/success_rtac_response_no_dueDate.json
@@ -1,9 +1,8 @@
 {
   "holdings" : [ {
     "id" : "53462dc6-55aa-4b99-8717-6ae8bbef5331",
-    "location" : "Popular Reading Collection",
+    "location" : "Demo library",
     "callNumber" : "MCN FICTION",
-    "status" : "Checked out",
-    "tempLocation" : "Demo library"
+    "status" : "Checked out"
   } ]
 }


### PR DESCRIPTION
The inventory interface introduced breaking changes that require users to get the current location of an item from the new "effectiveLocation" field. Items returned by inventory interface now have their own "permanentLocation" and "temporaryLocation" which are no longer inherited from the holdings record. Since we use those fields, which are now all unset/null, the "location" is no longer returned by rtac.

This change removes "tempLocation", which is no longer relevant, and uses "effecitveLocation" instead of the item's "permanentLocation". The rtac interface has also been updated to require inventory 5.3 and the rtac interface has been increased to 1.1. The interface has also been renamed from "mod-rtac" to "rtac", which is how most modules have declared their interfaces.

Since the inventory change was breaking, we have requested that the inventory's major version be increased. If this happens, we'll set the inventory interface dependency to "5.3 6.0".