### PR TITLE
Support either circulation 3.0 or 4.0 interfaces MODRTAC-3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-## 1.0.2 Unreleased
+## 1.1.0 Unreleased
+
+* Requires either `circulation` 3.0 or 4.0 (MODRTAC-3, CIRC-136)
 
 ## 1.0.1 2018-06-29
  * Added support for the new way item locations are set in mod-inventory.

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -36,7 +36,7 @@
     },
     {
       "id": "circulation",
-      "version": "3.0"
+      "version": "3.0 4.0"
     }
   ],
   "permissionSets": [

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-rtac</artifactId>
-  <version>1.0.2-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>


### PR DESCRIPTION
*Purpose*

Purpose

https://issues.folio.org/browse/MODRTAC-3
https://issues.folio.org/browse/CIRC-136
https://issues.folio.org/browse/CIRCSTORE-71

In order to support anonymization of loans the relationship between a loan and a user needs to be optional for closed loans.

This change requires making the userId property in the loan schema optional which is a potentially compatibility breaking change.

*Approach*

* Investigated the code for uses of `userId` from a loan (couldn't find any)
* Changed the interface requirements in the module descriptor to support both 3.0 and 4.0 or greater
* Changed the implementation version (and news) to reflect this (minor increment, and there does not appear to be any changes since the last release, 1.0.1)
* Registered the module with Okapi locally to check that the descriptor changes didn't break registration (did not try activation for a tenant)