### PR TITLE
Fixes for MODRTAC-1 and MODRTAC-2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## 1.1.0 Unreleased
-
-* Requires either `circulation` 3.0 or 4.0 (MODRTAC-3, CIRC-136)
+ * Updated the query limit value from `100` to `Integer.MAX_VALUE` (MODRTAC-2)
+ * Requires either `circulation` 3.0 or 4.0 (MODRTAC-3, CIRC-136)
 
 ## 1.0.1 2018-06-29
  * Added support for the new way item locations are set in mod-inventory.

--- a/pom.xml
+++ b/pom.xml
@@ -442,6 +442,6 @@
   </ciManagement>
   <issueManagement>
     <system>JIRA</system>
-    <url>https://issues.folio.org/projects/FOLIO</url>
+    <url>https://issues.folio.org/projects/MODRTAC</url>
   </issueManagement>
 </project>

--- a/src/main/java/org/folio/rest/impl/RTACResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/RTACResourceImpl.java
@@ -128,7 +128,7 @@ public final class RTACResourceImpl implements RTACResource {
   private CompletableFuture<Response> getHoldings(String id,
       HttpClientInterface httpClient, Map<String, String> okapiHeaders) {
     try {
-      return httpClient.request("/holdings-storage/holdings?limit=100&query=instanceId%3D%3D" + id, okapiHeaders);
+      return httpClient.request("/holdings-storage/holdings?limit=" + Integer.MAX_VALUE + "&query=instanceId%3D%3D" + id, okapiHeaders);
     } catch (Exception e) {
       throw new CompletionException(e);
     }
@@ -149,7 +149,7 @@ public final class RTACResourceImpl implements RTACResource {
       if (o instanceof JsonObject) {
         final JsonObject jo = (JsonObject) o;
         try {
-          cfs.put(httpClient.request("/inventory/items?limit=100&query=holdingsRecordId%3D%3D" + jo.getString("id"), okapiHeaders), jo.getString("callNumber"));
+          cfs.put(httpClient.request("/inventory/items?limit=" + Integer.MAX_VALUE + "&query=holdingsRecordId%3D%3D" + jo.getString("id"), okapiHeaders), jo.getString("callNumber"));
         } catch (Exception e) {
           throw new CompletionException(e);
         }
@@ -166,7 +166,7 @@ public final class RTACResourceImpl implements RTACResource {
     for (Holding holding : holdings.getHoldings()) {
       try {
         cfs.put(holding,
-            httpClient.request("/circulation/loans?limit=100&query=%28itemId%3D%3D"
+            httpClient.request("/circulation/loans?limit=" + Integer.MAX_VALUE + "&query=%28itemId%3D%3D"
                 + holding.getId() + "%20and%20status.name%3D%3DOpen%29",
                 okapiHeaders));
       } catch (Exception e) {

--- a/src/test/java/org/folio/rest/impl/RTACResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/RTACResourceImplTest.java
@@ -91,22 +91,22 @@ public class RTACResourceImplTest {
           .putHeader("content-type", "application/json")
           .end(readMockFile("RTACResourceImpl/success_instance_4.json"));
       } else if (req.path().equals("/holdings-storage/holdings")) {
-        if (req.query().equals(String.format("limit=100&query=instanceId%%3D%%3D%s", "76d5a72a-af24-4ac6-8e73-4e39604f6f59"))) {
+        if (req.query().equals(String.format("limit=%d&query=instanceId%%3D%%3D%s", Integer.MAX_VALUE, "76d5a72a-af24-4ac6-8e73-4e39604f6f59"))) {
           req.response()
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
             .end(readMockFile("RTACResourceImpl/success_holdings.json"));
-        } else if (req.query().equals(String.format("limit=100&query=instanceId%%3D%%3D%s", "1613697d-5e18-49b0-9613-08443b87cbc7"))) {
+        } else if (req.query().equals(String.format("limit=%d&query=instanceId%%3D%%3D%s", Integer.MAX_VALUE, "1613697d-5e18-49b0-9613-08443b87cbc7"))) {
           req.response()
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
             .end(readMockFile("RTACResourceImpl/success_no_holdings.json"));
-        } else if (req.query().equals(String.format("limit=100&query=instanceId%%3D%%3D%s", "2ae0635e-5534-4b7d-b28f-f0816329baa3"))) {
+        } else if (req.query().equals(String.format("limit=%d&query=instanceId%%3D%%3D%s", Integer.MAX_VALUE, "2ae0635e-5534-4b7d-b28f-f0816329baa3"))) {
           req.response()
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
             .end(readMockFile("RTACResourceImpl/success_holdings_2.json"));
-        } else if (req.query().equals(String.format("limit=100&query=instanceId%%3D%%3D%s", "0085f8ed-80ba-435b-8734-d3262aa4fc07"))) {
+        } else if (req.query().equals(String.format("limit=%d&query=instanceId%%3D%%3D%s", Integer.MAX_VALUE, "0085f8ed-80ba-435b-8734-d3262aa4fc07"))) {
           req.response()
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
@@ -115,22 +115,22 @@ public class RTACResourceImplTest {
           req.response().setStatusCode(500).end("Unexpected call: " + req.path());
         }
       } else if (req.path().equals("/inventory/items")) {
-        if (req.query().equals(String.format("limit=100&query=holdingsRecordId%%3D%%3D%s", "13269e78-d7bd-4e7c-b06a-0a979238f3fd"))) {
+        if (req.query().equals(String.format("limit=%d&query=holdingsRecordId%%3D%%3D%s", Integer.MAX_VALUE, "13269e78-d7bd-4e7c-b06a-0a979238f3fd"))) {
           req.response()
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
             .end(readMockFile("RTACResourceImpl/success_items_1.json"));
-        } else if (req.query().equals(String.format("limit=100&query=holdingsRecordId%%3D%%3D%s", "9fec4043-6963-4e2f-8e48-c12f914462bb"))) {
+        } else if (req.query().equals(String.format("limit=%d&query=holdingsRecordId%%3D%%3D%s", Integer.MAX_VALUE, "9fec4043-6963-4e2f-8e48-c12f914462bb"))) {
           req.response()
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
             .end(readMockFile("RTACResourceImpl/success_items_2.json"));
-        } else if (req.query().equals(String.format("limit=100&query=holdingsRecordId%%3D%%3D%s", "2fad39ae-03f4-496f-9ae9-533ce08c7344"))) {
+        } else if (req.query().equals(String.format("limit=%d&query=holdingsRecordId%%3D%%3D%s", Integer.MAX_VALUE, "2fad39ae-03f4-496f-9ae9-533ce08c7344"))) {
           req.response()
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
             .end(readMockFile("RTACResourceImpl/success_items_3.json"));
-        } else if (req.query().equals(String.format("limit=100&query=holdingsRecordId%%3D%%3D%s", "aa3487a4-af65-4285-939c-05601b98827c"))) {
+        } else if (req.query().equals(String.format("limit=%d&query=holdingsRecordId%%3D%%3D%s", Integer.MAX_VALUE, "aa3487a4-af65-4285-939c-05601b98827c"))) {
           req.response()
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
@@ -139,32 +139,32 @@ public class RTACResourceImplTest {
           req.response().setStatusCode(500).end("Unexpected call: " + req.path());
         }
       } else if (req.path().equals("/circulation/loans")) {
-        if (req.query().equals(String.format("limit=100&query=%%28itemId%%3D%%3D%s%%20and%%20status.name%%3D%%3DOpen%%29", "1a2f476a-436b-4530-82fe-b21a22d55514"))) {
+        if (req.query().equals(String.format("limit=%d&query=%%28itemId%%3D%%3D%s%%20and%%20status.name%%3D%%3DOpen%%29", Integer.MAX_VALUE, "1a2f476a-436b-4530-82fe-b21a22d55514"))) {
           req.response()
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
             .end(readMockFile("RTACResourceImpl/success_loans_1.json"));
-        } else if (req.query().equals(String.format("limit=100&query=%%28itemId%%3D%%3D%s%%20and%%20status.name%%3D%%3DOpen%%29", "b116cfe0-b75f-4e12-bdb7-61b08505e164"))) {
+        } else if (req.query().equals(String.format("limit=%d&query=%%28itemId%%3D%%3D%s%%20and%%20status.name%%3D%%3DOpen%%29", Integer.MAX_VALUE, "b116cfe0-b75f-4e12-bdb7-61b08505e164"))) {
           req.response()
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
             .end(readMockFile("RTACResourceImpl/success_loans_2.json"));
-        } else if (req.query().equals(String.format("limit=100&query=%%28itemId%%3D%%3D%s%%20and%%20status.name%%3D%%3DOpen%%29", "a754a5d1-6bd4-4f41-8239-87b7afecccc6"))) {
+        } else if (req.query().equals(String.format("limit=%d&query=%%28itemId%%3D%%3D%s%%20and%%20status.name%%3D%%3DOpen%%29", Integer.MAX_VALUE, "a754a5d1-6bd4-4f41-8239-87b7afecccc6"))) {
           req.response()
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
             .end(readMockFile("RTACResourceImpl/success_loans_3.json"));
-        } else if (req.query().equals(String.format("limit=100&query=%%28itemId%%3D%%3D%s%%20and%%20status.name%%3D%%3DOpen%%29", "650559de-a159-4620-a923-11f38cfcdb87"))) {
+        } else if (req.query().equals(String.format("limit=%d&query=%%28itemId%%3D%%3D%s%%20and%%20status.name%%3D%%3DOpen%%29", Integer.MAX_VALUE, "650559de-a159-4620-a923-11f38cfcdb87"))) {
           req.response()
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
             .end(readMockFile("RTACResourceImpl/success_loans_4.json"));
-        } else if (req.query().equals(String.format("limit=100&query=%%28itemId%%3D%%3D%s%%20and%%20status.name%%3D%%3DOpen%%29", "64a37e8b-1967-4a7e-a20f-d7d2da96e8f6"))) {
+        } else if (req.query().equals(String.format("limit=%d&query=%%28itemId%%3D%%3D%s%%20and%%20status.name%%3D%%3DOpen%%29", Integer.MAX_VALUE, "64a37e8b-1967-4a7e-a20f-d7d2da96e8f6"))) {
           req.response()
             .setStatusCode(200)
             .putHeader("content-type", "application/json")
             .end(readMockFile("RTACResourceImpl/success_loans_5.json"));
-        } else if (req.query().equals(String.format("limit=100&query=%%28itemId%%3D%%3D%s%%20and%%20status.name%%3D%%3DOpen%%29", "53462dc6-55aa-4b99-8717-6ae8bbef5331"))) {
+        } else if (req.query().equals(String.format("limit=%d&query=%%28itemId%%3D%%3D%s%%20and%%20status.name%%3D%%3DOpen%%29", Integer.MAX_VALUE, "53462dc6-55aa-4b99-8717-6ae8bbef5331"))) {
           req.response()
             .setStatusCode(200)
             .putHeader("content-type", "application/json")


### PR DESCRIPTION
- MODRTAC-1: Updated the issues link in the POM file to point to the MODRTAC Jira project instead of the FOLIO project. The MODRTAC Jira project was added after the last mod-rtac release.

- MODRTAC-2: Updated the `limit` query parameter to `Integer.MAX_VALUE` when retrieving RTAC data from other modules. The old limit was `100`.