### PR TITLE
Fixes for MODRTAC-5 and MODRTAC-6

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 ## 1.2.0 Unreleased
+ * Added missing description fields to JSON schemas (MODRTAC-5)
+ * Requires either `circulation` 3.0, 4.0 or 5.0 (MODRTAC-6)
  * Requires either `inventory` 5.3, 6.0 or 7.0 (MODRTAC-4)
  * Requires either `holdings-storage` 1.2 or 2.0 (MODRTAC-4)
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "rtac",
-      "version": "1.1",
+      "version": "1.2",
       "handlers": [
         {
           "methods": ["GET"],
@@ -36,7 +36,7 @@
     },
     {
       "id": "circulation",
-      "version": "3.0 4.0"
+      "version": "3.0 4.0 5.0"
     }
   ],
   "permissionSets": [

--- a/ramls/holding.json
+++ b/ramls/holding.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "RTAC Holding Schema",
   "type": "object",
+  "description": "Real Time Availability Check (RTAC) holding details",
   "additionalProperties": false,
   "properties": {
     "id": {

--- a/ramls/holdings.json
+++ b/ramls/holdings.json
@@ -5,6 +5,7 @@
   "description": "Collection of holdings",
   "properties": {
     "holdings": {
+      "description": "Collection of holdings",
       "type": "array",
       "items": {
         "type": "object",


### PR DESCRIPTION
Version 5.0 of circulation is now available. Updated mod-rtac to be able to support this version. Also added descriptions to missing JSON schema entries.