### PR TITLE
Include 6.0 in supported circulation versions MODRTAC-11

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -36,7 +36,7 @@
     },
     {
       "id": "circulation",
-      "version": "3.0 4.0 5.0"
+      "version": "3.0 4.0 5.0 6.0"
     }
   ],
   "permissionSets": [


### PR DESCRIPTION
Can be included in the multiple support list as the only endpoint used is the loans collection which is unaffected by the changes in 6.0