### PR TITLE
Include 7.0 in supported circulation versions MODRTAC-12

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -36,7 +36,7 @@
     },
     {
       "id": "circulation",
-      "version": "3.0 4.0 5.0 6.0"
+      "version": "3.0 4.0 5.0 6.0 7.0"
     }
   ],
   "permissionSets": [


### PR DESCRIPTION
As the only endpoint used is the loans collection which is unaffected by the changes in 7.0