### PR TITLE
Add runtime scope to the aspectjrt dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@
       <groupId>org.aspectj</groupId>
       <artifactId>aspectjrt</artifactId>
       <version>1.8.9</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
The CI/CD pipeline does multiple maven builds per job. One of these builds includes `-DskipTests`. This causes the `maven-dependency-plugin` to issue the following warning:
```
[INFO] --- maven-dependency-plugin:3.1.1:analyze-only (analyze) @ mod-rtac ---
[WARNING] Unused declared dependencies found:
[WARNING]    org.aspectj:aspectjrt:jar:1.8.9:compile
```

We have the plugin configured to fail the build on warnings, which is a good thing, I think, since most build warnings are ignored and can be easily fixed, like this one.

The problem here, is we have declared `aspectjrt` as an explicit, compile time, dependency when it is not. During the regular build, when the unit tests are executed, the `aspectjrt` dependency is loaded as RMB dependencies use aspectj for data validation and possibly other things and this satisfies the dependency plugin. However, when the tests are skipped, the `aspectjrt` dependency is not loaded, causing this error. In this case we need to add the `runtime` scope to the dependency. My mistake was that I thought the dependency was satisfied during code generation, which it clearly isn't. Then again, `rt` in `aspectjrt` should have clued me in to the proper scope. 🙄

Also worth noting, `-DskipTests`, is only used in the **master** branch build. Other branch/PR builds do not use this maven argument, so that is why this was missed until merged into master.