### PR TITLE
MODRTAC-20, MODINVSTOR-364: Update holdings-storage API version to 4.0.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -32,7 +32,7 @@
     },
     {
       "id": "holdings-storage",
-      "version": "1.2 2.0 3.0"
+      "version": "1.2 2.0 3.0 4.0"
     },
     {
       "id": "circulation",


### PR DESCRIPTION
**Have to be merged with**: https://github.com/folio-org/mod-inventory-storage/pull/338