### PR TITLE
MODRTAC-28: Migrate to inventory v10.0 and circulation v9.0.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -28,7 +28,7 @@
   "requires": [
     {
       "id": "inventory",
-      "version": "8.0 9.0"
+      "version": "8.0 9.0 10.0"
     },
     {
       "id": "holdings-storage",
@@ -36,7 +36,7 @@
     },
     {
       "id": "circulation",
-      "version": "3.0 4.0 5.0 6.0 7.0 8.0"
+      "version": "3.0 4.0 5.0 6.0 7.0 8.0 9.0"
     }
   ],
   "permissionSets": [

--- a/src/test/resources/RTACResourceImpl/success_items_1.json
+++ b/src/test/resources/RTACResourceImpl/success_items_1.json
@@ -8,7 +8,7 @@
 			"title": "Testing RTAC for Dummies",
 			"holdingsRecordId": "13269e78-d7bd-4e7c-b06a-0a979238f3fd",
 			"barcode": "012345678901",
-			"copyNumbers": [],
+			"copyNumber": "cp1",
 			"notes": [],
 			"materialType": {
 				"id": "5ee11d91-f7e8-481d-b079-65d708582ccc",
@@ -47,7 +47,7 @@
 			"title": "Testing RTAC for Dummies",
 			"holdingsRecordId": "13269e78-d7bd-4e7c-b06a-0a979238f3fd",
 			"barcode": "012345678902",
-			"copyNumbers": [],
+			"copyNumber": "cp1",
 			"notes": [],
 			"materialType": {
 				"id": "5ee11d91-f7e8-481d-b079-65d708582ccc",
@@ -82,7 +82,7 @@
 			"title": "Testing RTAC for Dummies",
 			"holdingsRecordId": "13269e78-d7bd-4e7c-b06a-0a979238f3fd",
 			"barcode": "012345678903",
-			"copyNumbers": [],
+			"copyNumber": "cp1",
 			"notes": [],
 			"materialType": {
 				"id": "5ee11d91-f7e8-481d-b079-65d708582ccc",

--- a/src/test/resources/RTACResourceImpl/success_items_2.json
+++ b/src/test/resources/RTACResourceImpl/success_items_2.json
@@ -8,7 +8,7 @@
 			"title": "Testing RTAC for Dummies",
 			"holdingsRecordId": "9fec4043-6963-4e2f-8e48-c12f914462bb",
 			"barcode": "012345678904",
-			"copyNumbers": [],
+			"copyNumber": "cp1",
 			"notes": [],
 			"materialType": {
 				"id": "5ee11d91-f7e8-481d-b079-65d708582ccc",
@@ -44,7 +44,7 @@
 			"title": "Testing RTAC for Dummies",
 			"holdingsRecordId": "9fec4043-6963-4e2f-8e48-c12f914462bb",
 			"barcode": "012345678905",
-			"copyNumbers": [],
+			"copyNumber": "cp1",
 			"notes": [],
 			"materialType": {
 				"id": "5ee11d91-f7e8-481d-b079-65d708582ccc",

--- a/src/test/resources/RTACResourceImpl/success_items_4.json
+++ b/src/test/resources/RTACResourceImpl/success_items_4.json
@@ -8,7 +8,7 @@
       "title": "Testing RTAC for Dummies",
       "holdingsRecordId": "aa3487a4-af65-4285-939c-05601b98827c",
       "barcode": "012345678904",
-      "copyNumbers": [],
+      "copyNumber": "cp1",
       "notes": [],
       "materialType": {
         "id": "5ee11d91-f7e8-481d-b079-65d708582ccc",

--- a/src/test/resources/RTACResourceImpl/success_items_5.json
+++ b/src/test/resources/RTACResourceImpl/success_items_5.json
@@ -8,7 +8,7 @@
 			"title": "Testing RTAC for Dummies",
 			"holdingsRecordId": "2839b3fa-a47b-4283-bdc4-6ee54ac67b38",
 			"barcode": "012345678901",
-			"copyNumbers": [],
+			"copyNumber": "cp1",
 			"notes": [],
 			"materialType": {
 				"id": "5ee11d91-f7e8-481d-b079-65d708582ccc",
@@ -45,7 +45,7 @@
 			"title": "Testing RTAC for Dummies",
 			"holdingsRecordId": "2839b3fa-a47b-4283-bdc4-6ee54ac67b38",
 			"barcode": "012345678902",
-			"copyNumbers": [],
+			"copyNumber": "cp1",
 			"notes": [],
 			"materialType": {
 				"id": "5ee11d91-f7e8-481d-b079-65d708582ccc",
@@ -79,7 +79,7 @@
 			"title": "Testing RTAC for Dummies",
 			"holdingsRecordId": "2839b3fa-a47b-4283-bdc4-6ee54ac67b38",
 			"barcode": "012345678903",
-			"copyNumbers": [],
+			"copyNumber": "cp1",
 			"notes": [],
 			"materialType": {
 				"id": "5ee11d91-f7e8-481d-b079-65d708582ccc",
@@ -114,7 +114,7 @@
       "title": "Testing RTAC for Dummies",
       "holdingsRecordId": "2839b3fa-a47b-4283-bdc4-6ee54ac67b38",
       "barcode": "012345678904",
-      "copyNumbers": [],
+      "copyNumber": "cp1",
       "notes": [],
       "materialType": {
         "id": "5ee11d91-f7e8-481d-b079-65d708582ccc",
@@ -148,7 +148,7 @@
       "title": "Testing RTAC for Dummies",
       "holdingsRecordId": "2839b3fa-a47b-4283-bdc4-6ee54ac67b38",
       "barcode": "012345678905",
-      "copyNumbers": [],
+      "copyNumber": "cp1",
       "notes": [],
       "materialType": {
         "id": "5ee11d91-f7e8-481d-b079-65d708582ccc",
@@ -181,7 +181,7 @@
       "title": "Testing RTAC for Dummies",
       "holdingsRecordId": "2839b3fa-a47b-4283-bdc4-6ee54ac67b38",
       "barcode": "012345678906",
-      "copyNumbers": [],
+      "copyNumber": "cp1",
       "notes": [],
       "materialType": {
         "id": "5ee11d91-f7e8-481d-b079-65d708582ccc",
@@ -214,7 +214,7 @@
       "title": "Testing RTAC for Dummies",
       "holdingsRecordId": "2839b3fa-a47b-4283-bdc4-6ee54ac67b38",
       "barcode": "012345678906",
-      "copyNumbers": [],
+      "copyNumber": "cp1",
       "notes": [],
       "materialType": {
         "id": "5ee11d91-f7e8-481d-b079-65d708582ccc",
@@ -246,7 +246,7 @@
       "title": "Testing RTAC for Dummies",
       "holdingsRecordId": "2839b3fa-a47b-4283-bdc4-6ee54ac67b38",
       "barcode": "012345678906",
-      "copyNumbers": [],
+      "copyNumber": "cp1",
       "notes": [],
       "materialType": {
         "id": "5ee11d91-f7e8-481d-b079-65d708582ccc",


### PR DESCRIPTION
https://issues.folio.org/browse/MODRTAC-28: Migrate to new major version of item-storage, inventory, circulation.

Migrate to inventory:10.0 and circulation:9.0.

Changes:

### Item-storage:8.0, item-storage-batch-sync:0.2, inventory:10.0
Changes:
1. `item.status.name` has restricted to the following values:
* Available
* Awaiting pickup
* Awaiting delivery
* Checked out
* In process
* In transit
* Missing
* On order
* Paged
* Withdrawn
* Declared lost

2. *Item.status* and *item.status.name* are required now, no defaulting available anymore;
3. Array *item.copyNumbers* converted to a single value *copyNumber*;
4. Item.status.date is read-only field now and has date-time formatting now ("yyyy-MM-dd'T'HH:mm:ss.SSS+0000").

### circulation:9.0, requests-reports:0.6, request-move:0.6
1. Array *request.item.copyNumbers* has converted to a single value - *copyNumber*;
2. *request/loan.item.status.date* has date-time formatting.

**Have to be merged with** https://github.com/folio-org/mod-inventory-storage/pull/382