### PR TITLE
Better handle periodicals in response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -571,7 +571,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M5</version>
+        <version>2.22.2</version>
       </plugin>
     </plugins>
     <pluginManagement>

--- a/ramls/examples/rtac-request.sample
+++ b/ramls/examples/rtac-request.sample
@@ -5,5 +5,6 @@
     "100d10bf-2f06-4aa0-be15-0b95b2d9f9e3",
     "0aaef1ea-69eb-4f6e-a077-cea159317ce3",
     "1b74ab75-9f41-4837-8662-a1d99118008d"
-  ]
+  ],
+  "fullPeriodicals" : false
 }

--- a/ramls/inventory-hierarchy/inventory-instance-records.json
+++ b/ramls/inventory-hierarchy/inventory-instance-records.json
@@ -244,6 +244,8 @@
           "holdingsStatements": {
             "description": "Notes about action, copy, binding etc.",
             "type": "array",
+            "additionalItems": false,
+            "additionalProperties": false,
             "items": {
               "type": "object",
               "properties": {

--- a/ramls/inventory-hierarchy/inventory-instance-records.json
+++ b/ramls/inventory-hierarchy/inventory-instance-records.json
@@ -38,17 +38,6 @@
             "description": "Indicate if record should not be displayed in a discovery system",
             "type": "boolean"
           },
-          "holdingsType": {
-            "description": "Name of the holdings type",
-            "type": "string"
-          },
-          "formerIds": {
-            "type": "array",
-            "description": "Identifiers of previously assigned ID(s) to the holdings record",
-            "items": {
-              "type": "string"
-            }
-          },
           "location": {
             "description": "Holdings record effective location",
             "type": "object",
@@ -149,65 +138,6 @@
               "callNumber"
             ]
           },
-          "shelvingTitle": {
-            "description": "Indicates the shelving form of title",
-            "type": "string"
-          },
-          "acquisitionFormat": {
-            "description": "Format of holdings record acquisition",
-            "type": "string"
-          },
-          "acquisitionMethod": {
-            "description": "Method of holdings record acquisition",
-            "type": "string"
-          },
-          "receiptStatus": {
-            "description": "Receipt status (e.g. pending, awaiting receipt, partially received, fully received, receipt not required, and cancelled)",
-            "type": "string"
-          },
-          "electronicAccess": {
-            "description": "Aggregated electronic access from holdings",
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "uri": {
-                  "description": "Electronic access URI",
-                  "type": "string"
-                },
-                "name":
-                {
-                  "description": "Electronic access name",
-                  "type": "string"
-                },
-                "linkText": {
-                  "description": "Electronic access link text",
-                  "type": "string"
-                },
-                "publicNote": {
-                  "description": "Electronic access public note",
-                  "type": "string"
-                },
-                "relationshipId": {
-                  "description": "Electronic access relationship id",
-                  "type": "string",
-                  "$ref": "../uuid.json"
-                },
-                "materialsSpecification": {
-                  "description": "Electronic access materials specification",
-                  "type": "string"
-                }
-              },
-              "required": [
-                "uri",
-                "name",
-                "linkText",
-                "publicNote",
-                "relationshipId",
-                "materialsSpecification"
-              ]
-            }
-          },
           "notes": {
             "description": "Notes about action, copy, binding etc.",
             "type": "array",
@@ -228,18 +158,6 @@
                 "note"
               ]
             }
-          },
-          "illPolicy": {
-            "description": "Name of the ILL policy",
-            "type": "string"
-          },
-          "retentionPolicy": {
-            "description": "Records information regarding how long we have agreed to keep something",
-            "type": "string"
-          },
-          "digitizationPolicy": {
-            "description": "Records information regarding digitization aspects",
-            "type": "string"
           },
           "holdingsStatements": {
             "description": "Notes about action, copy, binding etc.",
@@ -309,95 +227,6 @@
           "copyNumber": {
             "description": "Piece ID (usually barcode) for systems that do not use holdings record",
             "type": "string"
-          },
-          "numberOfItems": {
-            "description": "Amount of items of holdings record",
-            "type": "string"
-          },
-          "receivingHistory": {
-            "description": "Receiving history of holdings record",
-            "type": "object",
-            "properties": {
-              "entries": {
-                "description": "Entries of receiving history",
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "publicDisplay": {
-                      "description": "Defines if the receiving history should be visible to the public",
-                      "type": "boolean"
-                    },
-                    "enumeration": {
-                      "description": "This is the volume/issue number (e.g. v.71:no.6-2)",
-                      "type": "string"
-                    },
-                    "chronology": {
-                      "description": "Repeated element from Receiving history - Enumeration AND Receiving history - Chronology",
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "publicDisplay",
-                    "enumeration",
-                    "chronology"
-                  ]
-                }
-              }
-            }
-          },
-          "tags": {
-            "description": "Arbitrary tags associated with this holding",
-            "type": "object",
-            "properties": {
-              "tagList": {
-                "description": "List of tags",
-                "type": "array",
-                "items": {
-                  "important": {
-                    "description": "Indicate if tag is important",
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          },
-          "statisticalCodes": {
-            "description": "Holdings record statistical codes",
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "description": "Unique ID of the statistical code",
-                  "type": "string",
-                  "$ref": "../uuid.json"
-                },
-                "code": {
-                  "description": "Statistical code, a distinct label",
-                  "type": "string"
-                },
-                "name": {
-                  "description": "Name or description of a statistical code",
-                  "type": "string"
-                },
-                "statisticalCodeType": {
-                  "description": "Name of a statistical code type",
-                  "type": "string"
-                },
-                "source": {
-                  "description": "Label indicating where the statistical code type entry originates from, i.e. 'folio' or 'local'",
-                  "type": "string"
-                }
-              },
-              "required": [
-                "id",
-                "code",
-                "name",
-                "statisticalCodeType",
-                "source"
-              ]
-            }
           }
         }
       },

--- a/ramls/rtac-request.json
+++ b/ramls/rtac-request.json
@@ -9,8 +9,14 @@
       "items": {
         "$ref": "uuid.json"
       }
+    },
+    "fullPeriodicals": {
+      "description": "if set to true, then item-level information is added to all periodicals without holdings-level information",
+      "type": "boolean",
+      "default": false
     }
   },
+  "additionalProperties": false,
   "required": [
     "instanceIds"
   ]

--- a/src/main/java/org/folio/clients/CirculationClient.java
+++ b/src/main/java/org/folio/clients/CirculationClient.java
@@ -50,7 +50,7 @@ class CirculationClient extends FolioClient {
     Promise<List<InventoryHoldingsAndItems>> promise = Promise.promise();
 
     if (CollectionUtils.isEmpty(inventoryInstances)) {
-      promise.fail(new HttpException(404, "Could not find inventory instances"));
+      promise.complete(inventoryInstances);
       return promise.future();
     }
 
@@ -60,6 +60,7 @@ class CirculationClient extends FolioClient {
     for (InventoryHoldingsAndItems inventoryInstance : inventoryInstances) {
       final List<Item> items = inventoryInstance.getItems();
       if (CollectionUtils.isEmpty(items)) {
+        instances.add(inventoryInstance);
         continue;
       }
 

--- a/src/main/java/org/folio/clients/FolioFacade.java
+++ b/src/main/java/org/folio/clients/FolioFacade.java
@@ -3,7 +3,6 @@ package org.folio.clients;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -21,7 +20,6 @@ public class FolioFacade {
   private final InventoryClient inventoryClient;
   private final CirculationClient circulationClient;
   private final Logger logger = LogManager.getLogger(getClass());
-  private final FolioToRtacMapper folioToRtacMapper = new FolioToRtacMapper();
   private final ErrorMapper errorMapper = new ErrorMapper();
 
   public FolioFacade(Map<String, String> okapiHeaders) {
@@ -42,7 +40,7 @@ public class FolioFacade {
         .compose(circulationClient::getLoansForItems)
         .compose(
             instances -> {
-              var notFoundInstances = new ArrayList<>(instanceIds);
+              var notFoundInstances = new ArrayList<>(rtacRequest.getInstanceIds());
               final var rtacHoldingsList = new ArrayList<RtacHoldings>();
               for (InventoryHoldingsAndItems instance : instances) {
                 RtacHoldings rtacHoldings = folioToRtacMapper.mapToRtac(instance);

--- a/src/main/java/org/folio/clients/FolioFacade.java
+++ b/src/main/java/org/folio/clients/FolioFacade.java
@@ -47,6 +47,10 @@ public class FolioFacade {
             .filter(this::validateUuid)
             .collect(Collectors.toList());
 
+    if (CollectionUtils.isEmpty(validUuids)) {
+      promise.fail(new HttpException(404, "Could not find inventory instances"));
+    }
+
     return inventoryClient
         .getItemAndHoldingInfo(validUuids)
         .compose(circulationClient::getLoansForItems)

--- a/src/main/java/org/folio/clients/FolioFacade.java
+++ b/src/main/java/org/folio/clients/FolioFacade.java
@@ -14,6 +14,7 @@ import org.folio.rest.jaxrs.model.LegacyHoldings;
 import org.folio.rest.jaxrs.model.RtacHoldings;
 import org.folio.rest.jaxrs.model.RtacHoldingsBatch;
 import org.folio.rtac.rest.exceptions.HttpException;
+import org.folio.rest.jaxrs.model.RtacRequest;
 
 public class FolioFacade {
 
@@ -31,14 +32,13 @@ public class FolioFacade {
   /**
    * Returns batch info for instances items and holdings.
    *
-   * @param instanceIds passed instances ids
+   * @param rtacRequest - request params
    * @return items and holdings for instances
    */
-  public Future<RtacHoldingsBatch> getItemAndHoldingInfo(List<String> instanceIds) {
+  public Future<RtacHoldingsBatch> getItemAndHoldingInfo(RtacRequest rtacRequest) {
     Promise<RtacHoldingsBatch> promise = Promise.promise();
-
-    return inventoryClient
-        .getItemAndHoldingInfo(instanceIds)
+    final var folioToRtacMapper = new FolioToRtacMapper(rtacRequest.getFullPeriodicals());
+    return inventoryClient.getItemAndHoldingInfo(rtacRequest.getInstanceIds())
         .compose(circulationClient::getLoansForItems)
         .compose(
             instances -> {

--- a/src/main/java/org/folio/clients/FolioFacade.java
+++ b/src/main/java/org/folio/clients/FolioFacade.java
@@ -3,6 +3,7 @@ package org.folio.clients;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -12,14 +13,15 @@ import org.folio.rest.jaxrs.model.InventoryHoldingsAndItems;
 import org.folio.rest.jaxrs.model.LegacyHoldings;
 import org.folio.rest.jaxrs.model.RtacHoldings;
 import org.folio.rest.jaxrs.model.RtacHoldingsBatch;
-import org.folio.rtac.rest.exceptions.HttpException;
 import org.folio.rest.jaxrs.model.RtacRequest;
+import org.folio.rtac.rest.exceptions.HttpException;
 
 public class FolioFacade {
 
+  private static final Logger logger = LogManager.getLogger();
+
   private final InventoryClient inventoryClient;
   private final CirculationClient circulationClient;
-  private final Logger logger = LogManager.getLogger(getClass());
   private final ErrorMapper errorMapper = new ErrorMapper();
 
   public FolioFacade(Map<String, String> okapiHeaders) {
@@ -68,11 +70,12 @@ public class FolioFacade {
    *
    * @param instanceId passed instances id
    * @return items and holdings for instances
-   * @deprecated this will be removed soon, use {@link FolioFacade#getItemAndHoldingInfo(List)}
+   * @deprecated will be removed soon, use {@link FolioFacade#getItemAndHoldingInfo(RtacRequest)}
    */
   @Deprecated(since = "1.6.0")
   public Future<LegacyHoldings> getItemAndHoldingInfo(String instanceId) {
     Promise<LegacyHoldings> promise = Promise.promise();
+    final var folioToRtacMapper = new FolioToRtacMapper(false);
 
     return inventoryClient
         .getItemAndHoldingInfo(List.of(instanceId))

--- a/src/main/java/org/folio/clients/InventoryClient.java
+++ b/src/main/java/org/folio/clients/InventoryClient.java
@@ -40,7 +40,7 @@ class InventoryClient extends FolioClient {
     Promise<List<InventoryHoldingsAndItems>> promise = Promise.promise();
 
     if (CollectionUtils.isEmpty(instanceIds)) {
-      promise.fail("InstanceIds is empty");
+      promise.fail(new HttpException(404, "Could not find inventory instances"));
       return promise.future();
     }
 

--- a/src/main/java/org/folio/mappers/FolioToRtacMapper.java
+++ b/src/main/java/org/folio/mappers/FolioToRtacMapper.java
@@ -40,11 +40,13 @@ public class FolioToRtacMapper {
 
     final var nested = new ArrayList<RtacHolding>();
     logger.info("Rtac handling periodicals: {}", fullPeriodicals);
-    if (!fullPeriodicals && isPeriodical(instance)) {
+    final var periodical = isPeriodical(instance);
+    if (!fullPeriodicals && periodical) {
       logger.debug("{} is a periodical, returning holding info", instance.getInstanceId());
       instance.getHoldings().stream().map(fromHoldingToRtacHolding).forEach(nested::add);
     } else {
-      logger.debug("{} is NOT a periodical, returning item info", instance.getInstanceId());
+      logger.debug(
+          "{} is a periodical: {}, returning item info", instance.getInstanceId(), periodical);
       instance.getItems().stream().map(fromItemToRtacHolding).forEach(nested::add);
     }
 

--- a/src/main/java/org/folio/mappers/FolioToRtacMapper.java
+++ b/src/main/java/org/folio/mappers/FolioToRtacMapper.java
@@ -6,6 +6,7 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.function.Function;
 
@@ -121,7 +122,7 @@ public class FolioToRtacMapper {
   }
 
   private boolean isPeriodical(InventoryHoldingsAndItems instance) {
-    return isPeriodicalByNatureOfContent(instance) || instance.getModeOfIssuance().equals("serial");
+    return isPeriodicalByNatureOfContent(instance) || Objects.equals(instance.getModeOfIssuance(), "serial");
   }
 
   private boolean isPeriodicalByNatureOfContent(InventoryHoldingsAndItems instance) {

--- a/src/main/java/org/folio/mappers/FolioToRtacMapper.java
+++ b/src/main/java/org/folio/mappers/FolioToRtacMapper.java
@@ -16,8 +16,6 @@ import org.folio.rest.jaxrs.model.InventoryHoldingsAndItems;
 import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.jaxrs.model.LegacyHolding;
 import org.folio.rest.jaxrs.model.LegacyHoldings;
-import org.folio.rest.jaxrs.model.LegacyHolding;
-import org.folio.rest.jaxrs.model.LegacyHoldings;
 import org.folio.rest.jaxrs.model.RtacHolding;
 import org.folio.rest.jaxrs.model.RtacHoldings;
 
@@ -69,13 +67,9 @@ public class FolioToRtacMapper {
    * This function is populating holding-level information for periodicals.
    * The following php script was taken as an example:
    * function holdingsLoad($response){
-   * <p>
    * $data = json_decode($response,true);
-   * <p>
    * $holdings = $data['holdingsRecords'];
-   * <p>
    * echo '<holdings>';
-   * <p>
    * foreach ($holdings as $holding){
    * $statement = $holding['holdingsStatements'][0]['statement'];
    * if ($statement == null){
@@ -90,7 +84,6 @@ public class FolioToRtacMapper {
    * <dueDate></dueDate>
    * </holding>';
    * };
-   * <p>
    * echo '</holdings>';
    * }
    *
@@ -105,7 +98,7 @@ public class FolioToRtacMapper {
               .withCallNumber(mapCallNumber(holding))
               .withLocation(mapLocation(holding))
               .withStatus(mapHoldingStatements(holding))
-              .withDueDate("");
+              .withDueDate(null);
 
   private String mapHoldingStatements(Holding holding) {
     final var holdingsStatements = holding.getHoldingsStatements();
@@ -122,10 +115,9 @@ public class FolioToRtacMapper {
 
   private String mapCallNumber(Item item) {
     final var callNumber = item.getCallNumber();
-    return assembleCallNumber(callNumber.getCallNumber(), callNumber.getPrefix(),
-      callNumber.getSuffix());
+    return assembleCallNumber(
+      callNumber.getCallNumber(), callNumber.getPrefix(), callNumber.getSuffix());
   }
-
 
   private String mapLocation(Holding holding) {
     return holding.getLocation().getPermanentLocation().getName();
@@ -161,13 +153,13 @@ public class FolioToRtacMapper {
 
     for (Item item : instance.getItems()) {
       final var rtacHolding =
-        new LegacyHolding()
-          .withId(item.getId())
-          .withLocation(mapLocation(item))
-          .withCallNumber(mapCallNumber(item))
-          .withStatus(item.getStatus())
-          .withDueDate(item.getDueDate())
-          .withVolume(mapVolume(item));
+          new LegacyHolding()
+              .withId(item.getId())
+              .withLocation(mapLocation(item))
+              .withCallNumber(mapCallNumber(item))
+              .withStatus(item.getStatus())
+              .withDueDate(item.getDueDate())
+              .withVolume(mapVolume(item));
 
       nested.add(rtacHolding);
     }

--- a/src/main/java/org/folio/mappers/FolioToRtacMapper.java
+++ b/src/main/java/org/folio/mappers/FolioToRtacMapper.java
@@ -98,13 +98,14 @@ public class FolioToRtacMapper {
    * @return holding information to be returned to the caller
    * @see <a href=https://issues.folio.org/browse/MODRTAC-37>MODRTAC-37</a>
    */
-
-  private final Function<Holding, RtacHolding> fromHoldingToRtacHolding = holding -> new RtacHolding()
-    .withId(holding.getId())
-    .withCallNumber(mapCallNumber(holding))
-    .withLocation(mapLocation(holding))
-    .withStatus(mapHoldingStatements(holding))
-    .withDueDate("");
+  private final Function<Holding, RtacHolding> fromHoldingToRtacHolding =
+      holding ->
+          new RtacHolding()
+              .withId(holding.getId())
+              .withCallNumber(mapCallNumber(holding))
+              .withLocation(mapLocation(holding))
+              .withStatus(mapHoldingStatements(holding))
+              .withDueDate("");
 
   private String mapHoldingStatements(Holding holding) {
     final var holdingsStatements = holding.getHoldingsStatements();
@@ -121,8 +122,8 @@ public class FolioToRtacMapper {
 
   private String mapCallNumber(Item item) {
     final var callNumber = item.getCallNumber();
-    return assembleCallNumber(
-      callNumber.getCallNumber(), callNumber.getPrefix(), callNumber.getSuffix());
+    return assembleCallNumber(callNumber.getCallNumber(), callNumber.getPrefix(),
+      callNumber.getSuffix());
   }
 
 
@@ -130,23 +131,19 @@ public class FolioToRtacMapper {
     return holding.getLocation().getPermanentLocation().getName();
   }
 
-  private boolean isPeriodical(InventoryHoldingsAndItems instance) {
-    return isPeriodicalByNatureOfContent(instance) || Objects.equals(instance.getModeOfIssuance(), "serial");
-  }
-
-  private boolean isPeriodicalByNatureOfContent(InventoryHoldingsAndItems instance) {
-    return instance.getNatureOfContent().stream().map(String::toLowerCase).anyMatch(
-      periodicalNames::contains);
-  }
-
   private String mapLocation(Item item) {
     return item.getLocation().getLocation().getName();
   }
 
-  private String mapCallNumber(Item item) {
-    final var callNumber = item.getCallNumber();
-    return assembleCallNumber(callNumber.getCallNumber(), callNumber.getPrefix(),
-      callNumber.getSuffix());
+  private boolean isPeriodical(InventoryHoldingsAndItems instance) {
+    return isPeriodicalByNatureOfContent(instance)
+        || Objects.equals(instance.getModeOfIssuance(), "serial");
+  }
+
+  private boolean isPeriodicalByNatureOfContent(InventoryHoldingsAndItems instance) {
+    return instance.getNatureOfContent().stream()
+        .map(String::toLowerCase)
+        .anyMatch(periodicalNames::contains);
   }
 
   /**
@@ -177,6 +174,7 @@ public class FolioToRtacMapper {
 
     return rtacHoldings.withHoldings(nested);
   }
+
   private String assembleCallNumber(String callNumber, String prefix, String suffix) {
     if (isNotEmpty(prefix)) {
       callNumber = prefix + " " + callNumber;

--- a/src/main/java/org/folio/mappers/FolioToRtacMapper.java
+++ b/src/main/java/org/folio/mappers/FolioToRtacMapper.java
@@ -4,13 +4,13 @@ import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.function.Function;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.rest.jaxrs.model.Holding;
 import org.folio.rest.jaxrs.model.InventoryHoldingsAndItems;
 import org.folio.rest.jaxrs.model.Item;
@@ -23,7 +23,7 @@ import org.folio.rest.jaxrs.model.RtacHoldings;
 
 public class FolioToRtacMapper {
 
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private final Logger logger = LogManager.getLogger(getClass());
   private final boolean fullPeriodicals;
   private static final List<String> periodicalNames = List.of("journal", "newspaper");
 

--- a/src/main/java/org/folio/rest/impl/RtacBatchResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/RtacBatchResourceImpl.java
@@ -24,7 +24,10 @@ public final class RtacBatchResourceImpl implements RtacBatch {
       Handler<AsyncResult<Response>> asyncResultHandler,
       Context vertxContext) {
 
-    logger.info("Batch API called: {}", entity);
+    logger.info(
+        "Batch API called:\n fullPeriodicals: {}\n instanceIds: {}",
+        entity.getFullPeriodicals(),
+        entity.getInstanceIds());
 
     final FolioFacade folioFacade = new FolioFacade(okapiHeaders);
 

--- a/src/main/java/org/folio/rest/impl/RtacBatchResourceImpl.java
+++ b/src/main/java/org/folio/rest/impl/RtacBatchResourceImpl.java
@@ -29,7 +29,7 @@ public final class RtacBatchResourceImpl implements RtacBatch {
     final FolioFacade folioFacade = new FolioFacade(okapiHeaders);
 
     folioFacade
-        .getItemAndHoldingInfo(entity.getInstanceIds())
+        .getItemAndHoldingInfo(entity)
         .onSuccess(
             result ->
                 asyncResultHandler.handle(

--- a/src/test/java/org/folio/mappers/FolioToRtacMapperTest.java
+++ b/src/test/java/org/folio/mappers/FolioToRtacMapperTest.java
@@ -1,0 +1,46 @@
+package org.folio.mappers;
+
+import static org.folio.rest.impl.MockData.INSTANCE_WITH_HOLDINGS_AND_ITEMS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.folio.rest.jaxrs.model.Item;
+import org.junit.jupiter.api.Test;
+
+class FolioToRtacMapperTest {
+
+  @Test
+  void testMapToRtacForAPeriodicalWithFullPeriodicalsTrue() {
+    final var folioToRtacMapper = new FolioToRtacMapper(true);
+
+    var inventoryHoldingsAndItems = INSTANCE_WITH_HOLDINGS_AND_ITEMS.withModeOfIssuance("serial");
+    Item item = INSTANCE_WITH_HOLDINGS_AND_ITEMS.getItems().get(0);
+
+    final var rtacHoldings = folioToRtacMapper.mapToRtac(inventoryHoldingsAndItems);
+
+    final var rtacHolding = rtacHoldings.getHoldings().get(0);
+
+    assertEquals(item.getId(), rtacHolding.getId());
+    assertEquals(item.getCallNumber().getCallNumber(), rtacHolding.getCallNumber());
+    assertEquals(item.getLocation().getLocation().getName(), rtacHolding.getLocation());
+    String expectedVolume = "(" + item.getEnumeration() + " " + item.getChronology() + ")";
+    assertEquals(expectedVolume, rtacHolding.getVolume());
+    assertEquals(item.getDueDate(), rtacHolding.getDueDate());
+  }
+
+  @Test
+  void testMapToRtacForAPeriodicalWithFullPeriodicalsFalse() {
+    final var folioToRtacMapper = new FolioToRtacMapper(false);
+
+    var inventoryHoldingsAndItems = INSTANCE_WITH_HOLDINGS_AND_ITEMS.withModeOfIssuance("serial");
+    final var holding = INSTANCE_WITH_HOLDINGS_AND_ITEMS.getHoldings().get(0);
+
+    final var rtacHoldings = folioToRtacMapper.mapToRtac(inventoryHoldingsAndItems);
+
+    final var rtacHolding = rtacHoldings.getHoldings().get(0);
+
+    assertEquals(holding.getId(), rtacHolding.getId());
+    assertEquals(holding.getCallNumber().getCallNumber(), rtacHolding.getCallNumber());
+    assertEquals(
+        holding.getLocation().getPermanentLocation().getName(), rtacHolding.getLocation());
+  }
+}

--- a/src/test/java/org/folio/mappers/FolioToRtacMapperTest.java
+++ b/src/test/java/org/folio/mappers/FolioToRtacMapperTest.java
@@ -1,6 +1,6 @@
 package org.folio.mappers;
 
-import static org.folio.rest.impl.MockData.INSTANCE_WITH_HOLDINGS_AND_ITEMS;
+import static org.folio.rest.impl.MockData.createInventoryHoldingsAndItems;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.folio.rest.jaxrs.model.Item;
@@ -11,12 +11,9 @@ class FolioToRtacMapperTest {
   @Test
   void testMapToRtacForAPeriodicalWithFullPeriodicalsTrue() {
     final var folioToRtacMapper = new FolioToRtacMapper(true);
-
-    var inventoryHoldingsAndItems = INSTANCE_WITH_HOLDINGS_AND_ITEMS.withModeOfIssuance("serial");
-    Item item = INSTANCE_WITH_HOLDINGS_AND_ITEMS.getItems().get(0);
-
+    var inventoryHoldingsAndItems = createInventoryHoldingsAndItems().withModeOfIssuance("serial");
+    Item item = inventoryHoldingsAndItems.getItems().get(0);
     final var rtacHoldings = folioToRtacMapper.mapToRtac(inventoryHoldingsAndItems);
-
     final var rtacHolding = rtacHoldings.getHoldings().get(0);
 
     assertEquals(item.getId(), rtacHolding.getId());
@@ -30,17 +27,13 @@ class FolioToRtacMapperTest {
   @Test
   void testMapToRtacForAPeriodicalWithFullPeriodicalsFalse() {
     final var folioToRtacMapper = new FolioToRtacMapper(false);
-
-    var inventoryHoldingsAndItems = INSTANCE_WITH_HOLDINGS_AND_ITEMS.withModeOfIssuance("serial");
-    final var holding = INSTANCE_WITH_HOLDINGS_AND_ITEMS.getHoldings().get(0);
-
+    var inventoryHoldingsAndItems = createInventoryHoldingsAndItems().withModeOfIssuance("serial");
+    final var holding = inventoryHoldingsAndItems.getHoldings().get(0);
     final var rtacHoldings = folioToRtacMapper.mapToRtac(inventoryHoldingsAndItems);
-
     final var rtacHolding = rtacHoldings.getHoldings().get(0);
 
     assertEquals(holding.getId(), rtacHolding.getId());
     assertEquals(holding.getCallNumber().getCallNumber(), rtacHolding.getCallNumber());
-    assertEquals(
-        holding.getLocation().getPermanentLocation().getName(), rtacHolding.getLocation());
+    assertEquals(holding.getLocation().getPermanentLocation().getName(), rtacHolding.getLocation());
   }
 }

--- a/src/test/java/org/folio/rest/impl/MockData.java
+++ b/src/test/java/org/folio/rest/impl/MockData.java
@@ -39,6 +39,8 @@ public class MockData {
   public static final String NONEXISTENT_INSTANCE_ID = "207dda4d-06dd-4822-856e-63ca5b6c7f1a";
   public static final String INSTANCE_ID_NO_ITEMS_AND_HOLDINGS =
       "4ed2a3b3-2fb4-414c-aa6f-a265685ca5a6";
+  public static final String INSTANCE_ID_NO_FULL_PERIODICALS =
+      "4ed2a3b3-2fb4-414c-aa6f-a265685ca5a7";
 
   public static final String LOAN_JSON;
   public static final String EMPTY_LOANS_JSON;
@@ -47,6 +49,7 @@ public class MockData {
   public static final InventoryHoldingsAndItems INSTANCE_WITHOUT_HOLDINGS_AND_ITEMS;
   public static final InventoryHoldingsAndItems INSTANCE_WITH_ITEM_WHICH_HAS_NOT_LOANS;
   public static final InventoryHoldingsAndItems INSTANCE_LOAN_STORAGE_ERROR;
+  public static final InventoryHoldingsAndItems INSTANCE_NO_FULL_PERIODICALS;
 
   public static final RtacRequest VALID_INSTANCE_IDS_RTAC_REQUEST;
   public static final RtacRequest RTAC_REQUEST_WITH_INSTANCE_NO_LOANS_ITEM;
@@ -78,6 +81,12 @@ public class MockData {
     INSTANCE_LOAN_STORAGE_ERROR =
         stringToPojo(INSTANCE_WITH_ITEM_AND_HOLDING_TEMPLATE, InventoryHoldingsAndItems.class);
     setItemId(INSTANCE_LOAN_STORAGE_ERROR, ITEM_ID_LOAN_STORAGE_ERROR);
+
+    INSTANCE_NO_FULL_PERIODICALS =
+      MockData.stringToPojo(
+        INSTANCE_WITH_ITEM_AND_HOLDING_TEMPLATE, InventoryHoldingsAndItems.class)
+        .withModeOfIssuance("serial")
+        .withInstanceId(INSTANCE_ID_NO_FULL_PERIODICALS);
 
     // === Rtac requests ====
     VALID_INSTANCE_IDS_RTAC_REQUEST =

--- a/src/test/java/org/folio/rest/impl/MockData.java
+++ b/src/test/java/org/folio/rest/impl/MockData.java
@@ -42,6 +42,11 @@ public class MockData {
   public static final String INSTANCE_ID_NO_FULL_PERIODICALS =
       "4ed2a3b3-2fb4-414c-aa6f-a265685ca5a7";
 
+  public static final String UUID_400 = "c031f1d4-09b0-11eb-adc1-0242ac120002";
+  public static final String UUID_500 = "c031f1d4-09b0-11eb-adc1-0242ac120003";
+  public static final String UUID_403 = "c031f1d4-09b0-11eb-adc1-0242ac120004";
+  public static final String UUID_404 = "c031f1d4-09b0-11eb-adc1-0242ac120005";
+
   public static final String LOAN_JSON;
   public static final String EMPTY_LOANS_JSON;
 
@@ -83,10 +88,10 @@ public class MockData {
     setItemId(INSTANCE_LOAN_STORAGE_ERROR, ITEM_ID_LOAN_STORAGE_ERROR);
 
     INSTANCE_NO_FULL_PERIODICALS =
-      MockData.stringToPojo(
-        INSTANCE_WITH_ITEM_AND_HOLDING_TEMPLATE, InventoryHoldingsAndItems.class)
-        .withModeOfIssuance("serial")
-        .withInstanceId(INSTANCE_ID_NO_FULL_PERIODICALS);
+        MockData.stringToPojo(
+                INSTANCE_WITH_ITEM_AND_HOLDING_TEMPLATE, InventoryHoldingsAndItems.class)
+            .withModeOfIssuance("serial")
+            .withInstanceId(INSTANCE_ID_NO_FULL_PERIODICALS);
 
     // === Rtac requests ====
     VALID_INSTANCE_IDS_RTAC_REQUEST =
@@ -120,6 +125,10 @@ public class MockData {
     } catch (JsonProcessingException ex) {
       throw new IllegalArgumentException("Invalid json. Cannot parse json structure." + ex);
     }
+  }
+
+  public static InventoryHoldingsAndItems createInventoryHoldingsAndItems() {
+    return stringToPojo(INSTANCE_WITH_ITEM_AND_HOLDING_TEMPLATE, InventoryHoldingsAndItems.class);
   }
 
   private static String getJsonObjectFromFile(String path) {

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -17,7 +17,6 @@ import org.apache.http.HttpStatus;
 
 public class MockServer {
 
-
   private static final String LOANS_URI = "/loan-storage/loans";
   private static final String INVENTORY_VIEW_URI = "/inventory-hierarchy/items-and-holdings";
 
@@ -54,14 +53,16 @@ public class MockServer {
   private void handleInventoryViewResponse(RoutingContext routingContext) {
     JsonObject jsonObject = routingContext.getBody().toJsonObject();
     JsonArray jsonArray = jsonObject.getJsonArray("instanceIds");
-    final var first = jsonArray.getString(0);
-    if (first.length() == 3) {
-      final var statusCode = Integer.parseInt(first);
-      routingContext
-          .response()
-          .setStatusCode(statusCode)
-          .putHeader("content-type", "text/plain")
-          .end("Internal Server Error");
+    var first = jsonArray.getString(0);
+
+    if (first.equals(MockData.UUID_400)) {
+      failureResponse(routingContext, 400, "Internal Server error");
+    } else if (first.equals(MockData.UUID_403)) {
+      failureResponse(routingContext, 403, "Internal Server error");
+    } else if (first.equals(MockData.UUID_404)) {
+      failureResponse(routingContext, 404, "Internal Server error");
+    } else if (first.equals(MockData.UUID_500)) {
+      failureResponse(routingContext, 500, "Internal Server error");
     } else if (jsonArray.contains(MockData.INSTANCE_ID)) {
       successResponse(
           routingContext, MockData.pojoToJson(MockData.INSTANCE_WITH_HOLDINGS_AND_ITEMS));

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -75,6 +75,8 @@ public class MockServer {
     } else if (jsonArray.contains(MockData.INSTANCE_ID_NO_ITEMS_AND_HOLDINGS)) {
       successResponse(
           routingContext, MockData.pojoToJson(MockData.INSTANCE_WITHOUT_HOLDINGS_AND_ITEMS));
+    } else if (jsonArray.contains(MockData.INSTANCE_ID_NO_FULL_PERIODICALS)) {
+      successResponse(routingContext, MockData.pojoToJson(MockData.INSTANCE_NO_FULL_PERIODICALS));
     } else {
       failureResponse(
           routingContext,

--- a/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
@@ -1,6 +1,10 @@
 package org.folio.rest.impl;
 
 import static org.folio.rest.impl.MockData.INSTANCE_ID;
+import static org.folio.rest.impl.MockData.UUID_400;
+import static org.folio.rest.impl.MockData.UUID_403;
+import static org.folio.rest.impl.MockData.UUID_404;
+import static org.folio.rest.impl.MockData.UUID_500;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -237,7 +241,7 @@ class RtacBatchResourceImplTest {
   }
 
   @Test
-  void shouldReturnEmptyHoldings_whenInstanceHasNotItems(VertxTestContext testContext) {
+  void shouldSkipInstance_whenInstanceHasNoHoldings(VertxTestContext testContext) {
     testContext.verify(
         () -> {
           String validInstanceIdsJson =
@@ -254,8 +258,7 @@ class RtacBatchResourceImplTest {
                   .body()
                   .asString();
           RtacHoldingsBatch rtacResponse = MockData.stringToPojo(body, RtacHoldingsBatch.class);
-          RtacHoldings rtacHoldings = rtacResponse.getHoldings().iterator().next();
-          assertTrue(rtacHoldings.getHoldings().isEmpty());
+          assertTrue(rtacResponse.getHoldings().isEmpty());
           testContext.completeNow();
         });
   }
@@ -310,9 +313,9 @@ class RtacBatchResourceImplTest {
     return Stream.of(
         // Even though we receive a 400, we need to return a 500 since there is nothing the client
         // can do to correct the 400. We'd have to correct it in the code.
-        Arguments.of("400", 500),
-        Arguments.of("403", 403),
-        Arguments.of("404", 404),
-        Arguments.of("500", 500));
+        Arguments.of(UUID_400, 500),
+        Arguments.of(UUID_403, 403),
+        Arguments.of(UUID_404, 404),
+        Arguments.of(UUID_500, 500));
   }
 }


### PR DESCRIPTION
## Purpose

Better handle periodicals in response

## Approach

Using https://github.com/folio-org/mod-rtac/pull/46 as a baseline. Adding support for a new parameter "fullPeriodicals". 

*    if it’s set to “true”, then item-level information is added to all periodicals without holdings-level information,
*    if it’s set to “false” or not defined, then holding-level information replaces item-level for periodicals.


Jira: https://issues.folio.org/browse/MODRTAC-37
Jira: https://issues.folio.org/browse/MODRTAC-38