### PR TITLE
MODRTAC-58 Upgrade to RAML Module Builder 33.x

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+## 3.0.0 IN PROGRESS
+
+* embed_postgres command line option is no longer supported (MODRTAC-58)
+* Upgrades to RAML-Module-Builder 33.0.0 (MODRTAC-58)
+* Upgrades to Vert.x 4.1.0.CR1 (MODRTAC-58)
+
 ## 2.1.0 2021-03-16
 
 * Upgrades to RAML Module Builder 32.1.0 ([MODRTAC-54](https://issues.folio.org/browse/MODRTAC-54))

--- a/pom.xml
+++ b/pom.xml
@@ -81,22 +81,6 @@
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
-      <artifactId>domain-models-interface-extensions</artifactId>
-      <version>32.1.0</version>
-      <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-all</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.folio</groupId>
       <artifactId>domain-models-api-aspects</artifactId>
       <version>${raml-module-builder.version}</version>
       <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-rtac</artifactId>
-  <version>2.2.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -20,9 +20,10 @@
     <http.port>8081</http.port>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
-    <raml-module-builder.version>32.1.0</raml-module-builder.version>
+    <raml-module-builder.version>33.0.0</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <log4j.version>2.13.3</log4j.version>
+    <vertx.version>4.1.0.CR1</vertx.version>
   </properties>
 
   <repositories>
@@ -32,6 +33,14 @@
       <url>https://repository.folio.org/repository/maven-folio</url>
     </repository>
   </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>folio-nexus</id>
+      <name>FOLIO Maven repository</name>
+      <url>https://repository.folio.org/repository/maven-folio</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <dependencyManagement>
     <dependencies>
@@ -52,7 +61,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.0.0</version>
+        <version>${vertx.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -73,7 +82,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-interface-extensions</artifactId>
-      <version>${raml-module-builder.version}</version>
+      <version>32.1.0</version>
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
@@ -275,46 +284,15 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.6.0</version>
+        <groupId>org.folio</groupId>
+        <artifactId>domain-models-maven-plugin</artifactId>
+        <version>${raml-module-builder.version}</version>
         <executions>
           <execution>
             <id>generate_interfaces</id>
-            <phase>generate-sources</phase>
             <goals>
               <goal>java</goal>
             </goals>
-            <configuration>
-              <mainClass>org.folio.rest.tools.GenerateRunner</mainClass>
-              <cleanupDaemonThreads>false</cleanupDaemonThreads>
-              <systemProperties>
-                <systemProperty>
-                  <key>project.basedir</key>
-                  <value>${basedir}</value>
-                </systemProperty>
-                <systemProperty>
-                  <key>raml_files</key>
-                  <value>${ramlfiles_path}</value>
-                </systemProperty>
-              </systemProperties>
-            </configuration>
-          </execution>
-          <execution>
-            <id>git submodule update</id>
-            <phase>initialize</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <executable>git</executable>
-              <arguments>
-                <argument>submodule</argument>
-                <argument>update</argument>
-                <argument>--init</argument>
-                <argument>--recursive</argument>
-              </arguments>
-            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
There is no version 33.0.0 for plugin 'domain-models-interface-extensions', so still use 32.1.0