### PR TITLE
MODRTAC-56 If fullPeriodicals = false then always return holdings information

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## 3.1.0 IN-PROGRESS
 
-* rtac-batch endpoint now correctly returns data for items with no holdings or items (MODRTAC-56)
+* rtac-batch endpoint now correctly returns data for instances with holdings but no items (MODRTAC-56)
 
 ## 3.0.0 2021-06-17
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 3.1.0 IN-PROGRESS
+
+* rtac-batch endpoint now correctly returns data for items with no holdings or items (MODRTAC-56)
+
 ## 3.0.0 2021-06-17
 
 * `embed_postgres` command line option is no longer supported (MODRTAC-58)

--- a/src/main/java/org/folio/clients/CirculationClient.java
+++ b/src/main/java/org/folio/clients/CirculationClient.java
@@ -58,6 +58,11 @@ class CirculationClient extends FolioClient {
             .filter(updatedInstance -> CollectionUtils.isNotEmpty(updatedInstance.getItems()))
             .map(updatedInstance -> processInstance(updatedInstance, httpClientRequest))
             .collect(Collectors.toCollection(ArrayList::new));
+            
+    if (futures.size() == 0) {
+      promise.complete(inventoryInstances);
+      return promise.future();
+    }
 
     CompositeFuture.all(futures)
         .onSuccess(updatedInstances -> promise.complete(updatedInstances.result().list()))

--- a/src/main/java/org/folio/mappers/FolioToRtacMapper.java
+++ b/src/main/java/org/folio/mappers/FolioToRtacMapper.java
@@ -41,13 +41,14 @@ public class FolioToRtacMapper {
     final var nested = new ArrayList<RtacHolding>();
     logger.info("Rtac handling periodicals: {}", fullPeriodicals);
     final var periodical = isPeriodical(instance);
-    if (!fullPeriodicals && periodical) {
-      logger.debug("{} is a periodical, returning holding info", instance.getInstanceId());
-      instance.getHoldings().stream().map(fromHoldingToRtacHolding).forEach(nested::add);
-    } else {
-      logger.debug(
-          "{} is a periodical: {}, returning item info", instance.getInstanceId(), periodical);
+
+    if (fullPeriodicals && periodical && instance.getItems().size() > 0) {
+      logger.info("{} is a periodical: {}, returning item info", 
+          instance.getInstanceId(), periodical);
       instance.getItems().stream().map(fromItemToRtacHolding).forEach(nested::add);
+    } else if (instance.getHoldings().size() > 0) {
+      logger.info("Returning holding info for item {}", instance.getInstanceId());
+      instance.getHoldings().stream().map(fromHoldingToRtacHolding).forEach(nested::add);
     }
 
     return rtacHoldings.withInstanceId(instance.getInstanceId()).withHoldings(nested);

--- a/src/main/java/org/folio/mappers/FolioToRtacMapper.java
+++ b/src/main/java/org/folio/mappers/FolioToRtacMapper.java
@@ -37,21 +37,30 @@ public class FolioToRtacMapper {
    */
   public RtacHoldings mapToRtac(InventoryHoldingsAndItems instance) {
     final var rtacHoldings = new RtacHoldings();
-
     final var nested = new ArrayList<RtacHolding>();
     logger.info("Rtac handling periodicals: {}", fullPeriodicals);
     final var periodical = isPeriodical(instance);
 
-    if (fullPeriodicals && periodical && instance.getItems().size() > 0) {
-      logger.info("{} is a periodical: {}, returning item info", 
-          instance.getInstanceId(), periodical);
-      instance.getItems().stream().map(fromItemToRtacHolding).forEach(nested::add);
-    } else if (instance.getHoldings().size() > 0) {
-      logger.info("Returning holding info for item {}", instance.getInstanceId());
+    if (instance.getItems().size() == 0 && instance.getHoldings().size() == 0) {
+      logger.info("{} has no items or holdings, skipping item/holdings mapping", 
+          instance.getInstanceId());
+      return rtacHoldings.withInstanceId(instance.getInstanceId());
+    } else if (instance.getItems().size() == 0 && instance.getHoldings().size() > 0) {
+      logger.info("{} has no items, mapping holdings data.", instance.getInstanceId());
       instance.getHoldings().stream().map(fromHoldingToRtacHolding).forEach(nested::add);
+      return rtacHoldings.withInstanceId(instance.getInstanceId()).withHoldings(nested);
+    } else if ((!periodical) || periodical && fullPeriodicals) {
+      logger.info("{} is a periodical with full item data requested,", 
+          instance.getInstanceId());  
+      logger.info("or a non-periodical. Mapping all holdings and item data.");
+      instance.getItems().stream().map(fromItemToRtacHolding).forEach(nested::add);
+      return rtacHoldings.withInstanceId(instance.getInstanceId()).withHoldings(nested);
+    } else {
+      logger.info("{} is a periodical with full item data not requested,", 
+          instance.getInstanceId());
+      instance.getHoldings().stream().map(fromHoldingToRtacHolding).forEach(nested::add);
+      return rtacHoldings.withInstanceId(instance.getInstanceId()).withHoldings(nested);
     }
-
-    return rtacHoldings.withInstanceId(instance.getInstanceId()).withHoldings(nested);
   }
 
   private final Function<Item, RtacHolding> fromItemToRtacHolding =

--- a/src/test/java/org/folio/rest/impl/MockData.java
+++ b/src/test/java/org/folio/rest/impl/MockData.java
@@ -67,7 +67,6 @@ public class MockData {
   public static final RtacRequest RTAC_REQUEST_WITH_INSTANCE_NO_ITEMS_AND_HOLDINGS;
   public static final RtacRequest RTAC_REQUEST_WITH_INSTANCE_HOLDINGS_NO_ITEMS;
 
-
   static {
     LOAN_JSON = getJsonObjectFromFile(LOAN_JSON_PATH);
     EMPTY_LOANS_JSON = getJsonObjectFromFile(EMPTY_LOANS_JSON_PATH);

--- a/src/test/java/org/folio/rest/impl/MockData.java
+++ b/src/test/java/org/folio/rest/impl/MockData.java
@@ -41,6 +41,8 @@ public class MockData {
       "4ed2a3b3-2fb4-414c-aa6f-a265685ca5a6";
   public static final String INSTANCE_ID_NO_FULL_PERIODICALS =
       "4ed2a3b3-2fb4-414c-aa6f-a265685ca5a7";
+  public static final String INSTANCE_ID_HOLDINGS_NO_ITEMS =
+      "3af1a3b3-2fb4-414c-aa6f-a265699ca5b6";
 
   public static final String UUID_400 = "c031f1d4-09b0-11eb-adc1-0242ac120002";
   public static final String UUID_500 = "c031f1d4-09b0-11eb-adc1-0242ac120003";
@@ -54,6 +56,7 @@ public class MockData {
   public static final InventoryHoldingsAndItems INSTANCE_WITHOUT_HOLDINGS_AND_ITEMS;
   public static final InventoryHoldingsAndItems INSTANCE_WITH_ITEM_WHICH_HAS_NOT_LOANS;
   public static final InventoryHoldingsAndItems INSTANCE_LOAN_STORAGE_ERROR;
+  public static final InventoryHoldingsAndItems INSTANCE_WITH_HOLDINGS_NO_ITEMS;
   public static final InventoryHoldingsAndItems INSTANCE_NO_FULL_PERIODICALS;
 
   public static final RtacRequest VALID_INSTANCE_IDS_RTAC_REQUEST;
@@ -62,6 +65,8 @@ public class MockData {
   public static final RtacRequest RTAC_REQUEST_WITH_INSTANCE_ID_INVENTORY_VIEW_ERROR;
   public static final RtacRequest RTAC_REQUEST_WITH_NON_EXISTED_INSTANCE_ID;
   public static final RtacRequest RTAC_REQUEST_WITH_INSTANCE_NO_ITEMS_AND_HOLDINGS;
+  public static final RtacRequest RTAC_REQUEST_WITH_INSTANCE_HOLDINGS_NO_ITEMS;
+
 
   static {
     LOAN_JSON = getJsonObjectFromFile(LOAN_JSON_PATH);
@@ -69,6 +74,12 @@ public class MockData {
 
     // === inventory view responses ====
     INSTANCE_WITH_ITEM_AND_HOLDING_TEMPLATE = getJsonObjectFromFile(INSTANCE_JSON_PATH);
+
+    INSTANCE_WITH_HOLDINGS_NO_ITEMS = 
+      stringToPojo(INSTANCE_WITH_ITEM_AND_HOLDING_TEMPLATE, InventoryHoldingsAndItems.class);
+    INSTANCE_WITH_HOLDINGS_NO_ITEMS.setInstanceId(INSTANCE_ID_HOLDINGS_NO_ITEMS);
+    INSTANCE_WITH_HOLDINGS_NO_ITEMS.withModeOfIssuance("serial");
+    INSTANCE_WITH_HOLDINGS_NO_ITEMS.setItems(Collections.emptyList());
 
     INSTANCE_WITHOUT_HOLDINGS_AND_ITEMS =
         stringToPojo(INSTANCE_WITH_ITEM_AND_HOLDING_TEMPLATE, InventoryHoldingsAndItems.class);
@@ -78,6 +89,7 @@ public class MockData {
 
     INSTANCE_WITH_HOLDINGS_AND_ITEMS =
         stringToPojo(INSTANCE_WITH_ITEM_AND_HOLDING_TEMPLATE, InventoryHoldingsAndItems.class);
+
     INSTANCE_WITH_ITEM_WHICH_HAS_NOT_LOANS =
         stringToPojo(INSTANCE_WITH_ITEM_AND_HOLDING_TEMPLATE, InventoryHoldingsAndItems.class);
     INSTANCE_WITH_ITEM_WHICH_HAS_NOT_LOANS.setInstanceId(INSTANCE_ID_WITH_NO_LOANS_ITEM);
@@ -109,6 +121,9 @@ public class MockData {
     RTAC_REQUEST_WITH_INSTANCE_NO_ITEMS_AND_HOLDINGS =
         new RtacRequest()
             .withInstanceIds(Collections.singletonList(INSTANCE_ID_NO_ITEMS_AND_HOLDINGS));
+    RTAC_REQUEST_WITH_INSTANCE_HOLDINGS_NO_ITEMS = 
+        new RtacRequest()
+            .withInstanceIds(Collections.singletonList(INSTANCE_ID_HOLDINGS_NO_ITEMS));
   }
 
   static String pojoToJson(Object pojo) {

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -78,6 +78,9 @@ public class MockServer {
           routingContext, MockData.pojoToJson(MockData.INSTANCE_WITHOUT_HOLDINGS_AND_ITEMS));
     } else if (jsonArray.contains(MockData.INSTANCE_ID_NO_FULL_PERIODICALS)) {
       successResponse(routingContext, MockData.pojoToJson(MockData.INSTANCE_NO_FULL_PERIODICALS));
+    } else if (jsonArray.contains(MockData.INSTANCE_ID_HOLDINGS_NO_ITEMS)) {
+      successResponse(
+          routingContext, MockData.pojoToJson(MockData.INSTANCE_WITH_HOLDINGS_NO_ITEMS));
     } else {
       failureResponse(
           routingContext,

--- a/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
@@ -28,8 +28,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.TimeZone;
 import java.util.stream.Stream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.jaxrs.model.RtacHolding;
@@ -52,7 +50,6 @@ class RtacBatchResourceImplTest {
 
   private final int okapiPort = NetworkUtils.nextFreePort();
   private static int mockPort = NetworkUtils.nextFreePort();
-  private static final Logger logger = LogManager.getLogger(RtacBatchResourceImplTest.class);
   private static final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
 
   private static final String SERVER_ERROR = "Internal Server Error";
@@ -165,7 +162,6 @@ class RtacBatchResourceImplTest {
                   .extract()
                   .body()
                   .asString();
-          logger.info("body is: " + body);
           RtacHoldingsBatch rtacResponse = MockData.stringToPojo(body, RtacHoldingsBatch.class);
           RtacHolding holding = getSingleHolding(rtacResponse);
           final var expected = dateFormat.parse(MockData.LOAN_DUE_DATE_FIELD_VALUE);

--- a/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
@@ -7,6 +7,7 @@ import static org.folio.rest.impl.MockData.UUID_404;
 import static org.folio.rest.impl.MockData.UUID_500;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
@@ -27,6 +28,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.TimeZone;
 import java.util.stream.Stream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.jaxrs.model.RtacHolding;
@@ -42,13 +45,14 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+
 @ExtendWith(VertxExtension.class)
 @TestInstance(PER_CLASS)
 class RtacBatchResourceImplTest {
 
   private final int okapiPort = NetworkUtils.nextFreePort();
   private static int mockPort = NetworkUtils.nextFreePort();
-
+  private static final Logger logger = LogManager.getLogger(RtacBatchResourceImplTest.class);
   private static final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
 
   private static final String SERVER_ERROR = "Internal Server Error";
@@ -161,6 +165,7 @@ class RtacBatchResourceImplTest {
                   .extract()
                   .body()
                   .asString();
+          logger.info("body is: " + body);
           RtacHoldingsBatch rtacResponse = MockData.stringToPojo(body, RtacHoldingsBatch.class);
           RtacHolding holding = getSingleHolding(rtacResponse);
           final var expected = dateFormat.parse(MockData.LOAN_DUE_DATE_FIELD_VALUE);
@@ -236,6 +241,30 @@ class RtacBatchResourceImplTest {
           assertTrue(rtacResponse.getHoldings().isEmpty());
           testContext.completeNow();
         });
+  }
+
+  @Test
+  void shouldProvideHoldingDataForPeriodicalsWithNoItemsWhenFullPeriodicalsFalse(
+      VertxTestContext testContext) {
+    testContext.verify(
+        () -> {
+          String validInstanceIdsJson =
+              pojoToJson(MockData.RTAC_REQUEST_WITH_INSTANCE_HOLDINGS_NO_ITEMS);
+          RequestSpecification request = createBaseRequest(validInstanceIdsJson);
+          String body =
+              request
+                  .when()
+                  .post()
+                  .then()
+                  .statusCode(200)
+                  .contentType(ContentType.JSON)
+                  .extract()
+                  .body()
+                  .asString();
+          RtacHoldingsBatch rtacResponse = MockData.stringToPojo(body, RtacHoldingsBatch.class);
+          assertFalse(rtacResponse.getHoldings().isEmpty());
+          testContext.completeNow();
+      });
   }
 
   private String pojoToJson(Object pojo) {


### PR DESCRIPTION
The overarching problem here was that mod-rtac has been written on the
assumption that instances cannot have holdings records without also 
having item records.  The error noted in the issue was coming from the
code that looks up loan data for item records-it was being passed holdings
data without item data, and was attempting to look for loan data on 
non-existent items.  I put in a check there to exit 
if there were no item records to look up.  The code that maps the data 
to the RTAC response also needed to be reworked, because it needed 
to take the possibility of there being holdings but no items into account when 
deciding how to map data and what to return.  That code may need some
refactoring-I tried to be as concise as possible but there's a lot of variables that
need to be checked at that stage: do you have a holdings record?  Do you 
have item records?  Are you a periodical?  Is the Full flag set? etc.  What I 
have is the best I could come up with.

I also wrote a test specifically for this condition.