### PR TITLE
MODRTAC-83: Upgrade to Log4J 2.16.0 (Juniper R2 2021)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 3.0.3 2021-12-15
+
+* Upgrade to Log4J 2.16.0. (CVE-2021-44228) (MODRTAC-83)
+
 ## 3.0.2 2021-08-05
 
 * Provides error when only instance is not found in inventory (MODRTAC-64)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## 3.0.3 2021-12-15
+## 3.0.3 IN-PROGRESS
 
 * Upgrade to Log4J 2.16.0. (CVE-2021-44228) (MODRTAC-83)
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
     <raml-module-builder.version>33.0.0</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <log4j.version>2.13.3</log4j.version>
+    <log4j.version>2.16.0</log4j.version>
     <vertx.version>4.1.0.CR1</vertx.version>
   </properties>
 


### PR DESCRIPTION
Resolve CVE-2021-44228 as per [MODRTAC-83](https://issues.folio.org/browse/MODRTAC-83).