### PR TITLE
MODRTAC-81: Upgrade to Log4J 2.16.0 (Lotus).

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 3.2.0 IN-PROGRESS
+
+* Upgrade to Log4J 2.16.0. (CVE-2021-44228) (MODRTAC-81)
+
 ## 3.1.0 2021-10-05
 
 * rtac-batch endpoint now correctly returns data for instances with holdings but no items (MODRTAC-56)

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
     <raml-module-builder.version>33.0.0</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <log4j.version>2.13.3</log4j.version>
+    <log4j.version>2.16.0</log4j.version>
     <vertx.version>4.1.0.CR1</vertx.version>
   </properties>
 


### PR DESCRIPTION
Resolve CVE-2021-44228 as per [MODRTAC-81](https://issues.folio.org/browse/MODRTAC-81).