### PR TITLE
MODRTAC-86: upgrading to RMB 33.2.4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 3.2.0 IN-PROGRESS
 
 * Upgrade to Log4J 2.16.0. (CVE-2021-44228) (MODRTAC-81)
+* Upgrade to RMB 33.2.4 (MODRTAC-86)
 
 ## 3.1.0 2021-10-05
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,10 +20,10 @@
     <http.port>8081</http.port>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
-    <raml-module-builder.version>33.0.0</raml-module-builder.version>
+    <raml-module-builder.version>33.2.4</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <log4j.version>2.16.0</log4j.version>
-    <vertx.version>4.1.0.CR1</vertx.version>
+    <vertx.version>4.1.4</vertx.version>
   </properties>
 
   <repositories>

--- a/src/test/java/org/folio/clients/InventoryClientTests.java
+++ b/src/test/java/org/folio/clients/InventoryClientTests.java
@@ -13,6 +13,7 @@ import static org.hamcrest.Matchers.empty;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
+import com.github.tomakehurst.wiremock.core.Options;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -28,7 +29,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class InventoryClientTests {
-  private final WireMockServer fakeWebServer = new WireMockServer();
+  private final WireMockServer fakeWebServer = 
+      new WireMockServer(Options.DYNAMIC_PORT);
 
   @BeforeEach
   @SneakyThrows


### PR DESCRIPTION
I had some test failures in master that I recognized as being due to
a port binding conflict.  This is why I've changed some of the test code
to use a dynamic port assignment.