### PR TITLE
MODRTAC-89: Fetch of holdings records fails for mixed instances

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 3.3.0 IN-PROGRESS
+
+* requests containing records with and without items now return holdings data for all records (MODRTAC-89)
+
 ## 3.2.0 2022-02-22
 
 * Upgrade to Log4J 2.16.0. (CVE-2021-44228) (MODRTAC-81)

--- a/src/main/java/org/folio/clients/CirculationClient.java
+++ b/src/main/java/org/folio/clients/CirculationClient.java
@@ -71,14 +71,10 @@ class CirculationClient extends FolioClient {
 
     CompositeFuture.all(futures)
         .onSuccess(updatedInstances -> {
-          if (instancesNoItems.size() > 0) {
-            List<InventoryHoldingsAndItems> combinedList = new ArrayList<>();
-            combinedList.addAll(updatedInstances.result().list());
-            combinedList.addAll(instancesNoItems);
-            promise.complete(combinedList);
-          } else {  
-            promise.complete(updatedInstances.result().list());
-          }
+          List<InventoryHoldingsAndItems> combinedList = new ArrayList<>();
+          combinedList.addAll(updatedInstances.result().list());
+          combinedList.addAll(instancesNoItems);
+          promise.complete(combinedList);
         })
         .onFailure(promise::fail);
 


### PR DESCRIPTION
I traced this problem to the part of the code that looks up circulation
data for any items attached to the requested instance records.  Because
of the way this code had been written, it effectively discarded any 
holdings information for instance records that did not have attached items.
Later code flags any records that don't have holdings data as 404 not found,
making it appear that the holdings data could not be retrieved.

To fix, I made a list of instance records without attached items, then merge this
list in later with the list of items that do, and return the merged list to the 
calling code.