### PR TITLE
MODRTAC-93 Upgrade to RMB 33.2.10.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,8 @@
     <http.port>8081</http.port>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
-    <raml-module-builder.version>33.2.4</raml-module-builder.version>
+    <raml-module-builder.version>33.2.10</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <log4j.version>2.16.0</log4j.version>
     <vertx.version>4.1.4</vertx.version>
   </properties>
 
@@ -47,7 +46,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>${log4j.version}</version>
+        <version>2.17.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
https://issues.folio.org/browse/MODRTAC-93

The log4j fails due to an exception at shutdown.
The 2.16.0 version of `log4j-bom` pulls in the dependencies that have the CVEs:
- [CVE-2021-45105](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105)
- [CVE-2021-44832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832)

Replace the managed `log4j-bom` with 2.17.2 to fix this problem and ensure the version with the CVE is never used in any manner.

I went with RMB 33.2.0 instead of 34.0.0 due to problems.

see: https://issues.apache.org/jira/browse/LOG4J2-1618
see: https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-bom/2.16.0