### PR TITLE
MODRTAC-93 Upgrade RMB to 34.0.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -444,6 +444,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,12 +15,12 @@
   </licenses>
 
   <properties>
-    <aspectj.version>1.9.6</aspectj.version>
+    <aspectj.version>1.9.7</aspectj.version>
     <module_name>mod-rtac</module_name>
     <http.port>8081</http.port>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
-    <raml-module-builder.version>33.2.10</raml-module-builder.version>
+    <raml-module-builder.version>34.0.0</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -218,6 +218,11 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>2.1.1</version>
     </dependency>
   </dependencies>
 
@@ -434,7 +439,7 @@
               <properties>
                 <property>
                   <name>log4j.configurationFile</name>
-                  <value>${project.baseUri}src/main/resources/log4j2-test.xml</value>
+                  <value>${project.baseUri}src/main/resources/log4j2.xml</value>
                 </property>
                 <property>
                   <name>vertx.logger-delegate-factory-class-name</name>

--- a/pom.xml
+++ b/pom.xml
@@ -521,7 +521,8 @@
             <configuration>
               <ignoreNonCompile>true</ignoreNonCompile>
               <failOnWarning>true</failOnWarning>
-              <ignoredDependencies>jakarta.ws.rs:jakarta.ws.rs-api:jar:2.1.6</ignoredDependencies>
+              <ignoredDependencies>jakarta.ws.rs:jakarta.ws.rs-api</ignoredDependencies>
+              <ignoredDependencies>javax.ws.rs:javax.ws.rs-api</ignoredDependencies>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -521,8 +521,10 @@
             <configuration>
               <ignoreNonCompile>true</ignoreNonCompile>
               <failOnWarning>true</failOnWarning>
-              <ignoredDependencies>jakarta.ws.rs:jakarta.ws.rs-api</ignoredDependencies>
-              <ignoredDependencies>javax.ws.rs:javax.ws.rs-api</ignoredDependencies>
+              <ignoredDependencies>
+                <ignoredDependency>jakarta.ws.rs:jakarta.ws.rs-api</ignoredDependency>
+                <ignoredDependency>javax.ws.rs:javax.ws.rs-api</ignoredDependency>
+              </ignoredDependencies>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -123,10 +123,9 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>2.0.1</version>
-      <scope>runtime</scope>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <version>3.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.aspectj</groupId>
@@ -218,11 +217,6 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
       <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>2.1.1</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/folio/clients/CirculationClient.java
+++ b/src/main/java/org/folio/clients/CirculationClient.java
@@ -1,8 +1,8 @@
 package org.folio.clients;
 
-import static javax.ws.rs.core.HttpHeaders.ACCEPT;
-import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.HttpHeaders.ACCEPT;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
 

--- a/src/main/java/org/folio/clients/InventoryClient.java
+++ b/src/main/java/org/folio/clients/InventoryClient.java
@@ -1,9 +1,9 @@
 
 package org.folio.clients;
 
-import static javax.ws.rs.core.HttpHeaders.ACCEPT;
-import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.HttpHeaders.ACCEPT;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
 

--- a/src/test/java/org/folio/clients/InventoryClientTests.java
+++ b/src/test/java/org/folio/clients/InventoryClientTests.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.folio.rest.jaxrs.model.InventoryHoldingsAndItems;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -119,13 +120,12 @@ public class InventoryClientTests {
     private static final String tenantId = "test-tenant";
     // Cannot be a representative token because it fails checkstyle
     private static final String token = "fake-token";
-    
+
     static Map<String, String> toMap(String okapiUrl) {
-      return Map.of(
+      return new CaseInsensitiveMap<>(Map.of(
         "X-Okapi-Url", okapiUrl,
-        // RMB defines lower case definitions for these headers
         "x-okapi-tenant", Headers.tenantId,
-        "x-okapi-token", Headers.token);
+        "x-okapi-token", Headers.token));
     }
   }
 }


### PR DESCRIPTION
https://issues.folio.org/browse/MODRTAC-93

There are several dependency changes that ended up being made that should be closely looked at.

The previous `javax.ws.rs-api` no longer works and is replaced with `jakarta.ws.rs-api`.
Doing this brings in its own set of problems that have also been resolved.

There are also changes applied that are necessary as per the RMB 34.0.0 upgrade documentation.