### PR TITLE
MODRTAC-88: Separate error message for not found instances

### DIFF
--- a/src/main/java/org/folio/mappers/ErrorMapper.java
+++ b/src/main/java/org/folio/mappers/ErrorMapper.java
@@ -41,7 +41,7 @@ public class ErrorMapper {
         .collect(Collectors.toList());
   }
 
-  private Error createErrorMessage(String str, String message) {
+  private Error createErrorMessage(String instanceId, String message) {
     final var error = new Error();
     error.withCode(String.valueOf(NOT_FOUND.getStatusCode()));
     return error.withMessage(String.format(message, str)).withParameters(null);

--- a/src/main/java/org/folio/mappers/ErrorMapper.java
+++ b/src/main/java/org/folio/mappers/ErrorMapper.java
@@ -14,21 +14,37 @@ import org.folio.rtac.rest.exceptions.HttpException;
 
 public class ErrorMapper {
 
-  private static final String NOT_FOUND_MESSAGE = "Instance %s can not be retrieved";
+  private static final String INSTANCE_NOT_FOUND_MESSAGE = "Instance %s can not be retrieved";
+  private static final String HOLDINGS_NOT_FOUND_MESSAGE = "Holdings not found for instance %s";
 
   /**
    * RTac mapper class.
    *
    * @param ids - not found instanceIds
    */
-  public List<Error> mapNotFoundInstances(List<String> ids) {
-    return ids.stream().map(this::createErrorMessage).collect(Collectors.toList());
+  public List<Error> mapInstanceNotFound(List<String> ids) {
+    return ids
+        .stream()
+        .map(id -> createErrorMessage(id, INSTANCE_NOT_FOUND_MESSAGE))
+        .collect(Collectors.toList());
+  }
+  
+  /**
+   * RTac mapper class.
+   *
+   * @param ids - not found instanceIds
+   */
+  public List<Error> mapHoldingsNotFound(List<String> ids) {
+    return ids
+        .stream()
+        .map(id -> createErrorMessage(id, HOLDINGS_NOT_FOUND_MESSAGE))
+        .collect(Collectors.toList());
   }
 
-  private Error createErrorMessage(String str) {
+  private Error createErrorMessage(String str, String message) {
     final var error = new Error();
     error.withCode(String.valueOf(NOT_FOUND.getStatusCode()));
-    return error.withMessage(String.format(NOT_FOUND_MESSAGE, str)).withParameters(null);
+    return error.withMessage(String.format(message, str)).withParameters(null);
   }
 
   /**

--- a/src/main/java/org/folio/mappers/ErrorMapper.java
+++ b/src/main/java/org/folio/mappers/ErrorMapper.java
@@ -44,7 +44,7 @@ public class ErrorMapper {
   private Error createErrorMessage(String instanceId, String message) {
     final var error = new Error();
     error.withCode(String.valueOf(NOT_FOUND.getStatusCode()));
-    return error.withMessage(String.format(message, str)).withParameters(null);
+    return error.withMessage(String.format(message, instanceId)).withParameters(null);
   }
 
   /**

--- a/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
@@ -242,7 +242,7 @@ class RtacBatchResourceImplTest {
   }
 
   @Test
-  void shouldAttachError_whenNonexistentInstanceRequested(VertxTestContext testContext) {
+  void shouldAttachError_whenInstanceIsNotFound(VertxTestContext testContext) {
     testContext.verify(
         () -> {
           String invalidInstanceIdsJson =

--- a/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import java.util.TimeZone;
 import java.util.stream.Stream;
 import org.folio.rest.RestVerticle;
+import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.jaxrs.model.RtacHolding;
 import org.folio.rest.jaxrs.model.RtacHoldingsBatch;
@@ -215,7 +216,7 @@ class RtacBatchResourceImplTest {
   }
 
   @Test
-  void shouldSkipInstance_whenInstanceHasNoHoldings(VertxTestContext testContext) {
+  void shouldAttachError_whenInstanceHasNoHoldings(VertxTestContext testContext) {
     testContext.verify(
         () -> {
           String validInstanceIdsJson =
@@ -233,10 +234,38 @@ class RtacBatchResourceImplTest {
                   .asString();
           RtacHoldingsBatch rtacResponse = MockData.stringToPojo(body, RtacHoldingsBatch.class);
           assertTrue(rtacResponse.getHoldings().isEmpty());
+          Error error = rtacResponse.getErrors().get(0);
+          String msg = "Holdings not found for instance 4ed2a3b3-2fb4-414c-aa6f-a265685ca5a6";
+          assertEquals(error.getMessage(), msg);
           testContext.completeNow();
         });
   }
 
+  @Test
+  void shouldAttachError_whenNonexistentInstanceRequested(VertxTestContext testContext) {
+    testContext.verify(
+        () -> {
+          String invalidInstanceIdsJson =
+              pojoToJson(MockData.RTAC_REQUEST_WITH_NON_EXISTED_INSTANCE_ID);
+          RequestSpecification request = createBaseRequest(invalidInstanceIdsJson);
+          String body =
+              request
+                .when()
+                .post()
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .extract()
+                .body()
+                .asString();
+          RtacHoldingsBatch rtacResponse = MockData.stringToPojo(body, RtacHoldingsBatch.class);
+          Error error = rtacResponse.getErrors().get(0);
+          String msg = "Instance 207dda4d-06dd-4822-856e-63ca5b6c7f1a can not be retrieved";
+          assertEquals(error.getMessage(), msg);
+          testContext.completeNow();
+        });
+  }
+  
   @Test
   void shouldProvideHoldingsData_whenInstancesWithAndWithoutItemsRequested(
       VertxTestContext testContext) {


### PR DESCRIPTION
I modified the code in folioFacade that forms the response to requests.

I also modified the errorMapper class so that there are two separate error
messages for no holdings and no instance found.

Finally, I modified and created new tests to check for the new error messages.