### PR TITLE
MODRTAC-99: Upgrade to RAML Module Builder 35.x.x.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 3.4.0 IN-PROGRESS
+
+* Upgraded RMB to 35.0.0 ([MODRTAC-99](https://issues.folio.org/browse/MODRTAC-99)
+
 ## 3.3.0 2022-06-14
 
 * requests containing records with and without items now return holdings data for all records ([MODRTAC-89](https://issues.folio.org/browse/MODRTAC-89))

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <http.port>8081</http.port>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
-    <raml-module-builder.version>35.0.0</raml-module-builder.version> <!-- also update vertx.version -->
+    <raml-module-builder.version>35.0.1</raml-module-builder.version> <!-- also update vertx.version -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -58,7 +58,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.3.3</version>
+        <version>4.3.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <http.port>8081</http.port>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
-    <raml-module-builder.version>34.0.0</raml-module-builder.version>
+    <raml-module-builder.version>35.0.0</raml-module-builder.version> <!-- also update vertx.version -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -58,7 +58,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.3.1</version>
+        <version>4.3.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
https://issues.folio.org/browse/MODRTAC-99