### PR TITLE
[MODRTAC-107]. Add new displaySummarry field

### DIFF
--- a/ramls/inventory-hierarchy/inventory-instance-records.json
+++ b/ramls/inventory-hierarchy/inventory-instance-records.json
@@ -387,6 +387,10 @@
             "description": "Descriptive information for the dating scheme of a serial",
             "type": "string"
           },
+          "displaySummary": {
+            "description": "Display summary about the item",
+            "type": "string"
+          },
           "itemIdentifier": {
             "description": "Item identifier number, e.g. imported from the union catalogue",
             "type": "string"

--- a/src/main/java/org/folio/mappers/FolioToRtacMapper.java
+++ b/src/main/java/org/folio/mappers/FolioToRtacMapper.java
@@ -219,9 +219,6 @@ public class FolioToRtacMapper {
       if (isNotBlank(chronology)) {
         sj.add(chronology);
       }
-      if (isNotBlank(displaySummary)) {
-        sj.add(displaySummary);
-      }
     } else if (isNotBlank(volume)) {
       sj.add(volume);
     } else if (isNotBlank(chronology)) {

--- a/src/main/java/org/folio/mappers/FolioToRtacMapper.java
+++ b/src/main/java/org/folio/mappers/FolioToRtacMapper.java
@@ -195,7 +195,6 @@ public class FolioToRtacMapper {
    * The rules for generating "volume" are as follows:
    * |data set                     |"volume"                    |
    * |-----------------------------|----------------------------|
-   * |displaySummary               |(displaySummary)            |
    * |enumeration                  |(enumeration)               |
    * |enumeration chronology       |(enumeration chronology)    |
    * |enumeration chronology volume|(enumeration chronology)    |
@@ -206,9 +205,9 @@ public class FolioToRtacMapper {
    * @param item - folio inventory item
    */
   private String mapVolume(Item item) {
-    final String displaySummary = item.getDisplaySummary();
     final String enumeration = item.getEnumeration();
     final String chronology = item.getChronology();
+    final String displaySummary = item.getDisplaySummary();
     final String volume = item.getVolume();
 
     final StringJoiner sj = new StringJoiner(" ", "(", ")").setEmptyValue("");

--- a/src/main/java/org/folio/mappers/FolioToRtacMapper.java
+++ b/src/main/java/org/folio/mappers/FolioToRtacMapper.java
@@ -42,7 +42,7 @@ public class FolioToRtacMapper {
     final var periodical = isPeriodical(instance);
 
     if (instance.getItems().size() == 0 && instance.getHoldings().size() == 0) {
-      logger.info("{} has no items or holdings, skipping item/holdings mapping", 
+      logger.info("{} has no items or holdings, skipping item/holdings mapping",
           instance.getInstanceId());
       return rtacHoldings.withInstanceId(instance.getInstanceId());
     } else if (instance.getItems().size() == 0 && instance.getHoldings().size() > 0) {
@@ -50,13 +50,13 @@ public class FolioToRtacMapper {
       instance.getHoldings().stream().map(fromHoldingToRtacHolding).forEach(nested::add);
       return rtacHoldings.withInstanceId(instance.getInstanceId()).withHoldings(nested);
     } else if ((!periodical) || periodical && fullPeriodicals) {
-      logger.info("{} is a periodical with full item data requested,", 
-          instance.getInstanceId());  
+      logger.info("{} is a periodical with full item data requested,",
+          instance.getInstanceId());
       logger.info("or a non-periodical. Mapping all holdings and item data.");
       instance.getItems().stream().map(fromItemToRtacHolding).forEach(nested::add);
       return rtacHoldings.withInstanceId(instance.getInstanceId()).withHoldings(nested);
     } else {
-      logger.info("{} is a periodical with full item data not requested,", 
+      logger.info("{} is a periodical with full item data not requested,",
           instance.getInstanceId());
       instance.getHoldings().stream().map(fromHoldingToRtacHolding).forEach(nested::add);
       return rtacHoldings.withInstanceId(instance.getInstanceId()).withHoldings(nested);
@@ -207,6 +207,7 @@ public class FolioToRtacMapper {
   private String mapVolume(Item item) {
     final String enumeration = item.getEnumeration();
     final String chronology = item.getChronology();
+    final String displaySummary = item.getDisplaySummary();
     final String volume = item.getVolume();
 
     final StringJoiner sj = new StringJoiner(" ", "(", ")").setEmptyValue("");
@@ -216,10 +217,15 @@ public class FolioToRtacMapper {
       if (isNotBlank(chronology)) {
         sj.add(chronology);
       }
+      if (isNotBlank(displaySummary)) {
+        sj.add(displaySummary);
+      }
     } else if (isNotBlank(volume)) {
       sj.add(volume);
     } else if (isNotBlank(chronology)) {
       sj.add(chronology);
+    } else if (isNotBlank(displaySummary)) {
+      sj.add(displaySummary);
     }
 
     return defaultIfEmpty(sj.toString(), null);

--- a/src/main/java/org/folio/mappers/FolioToRtacMapper.java
+++ b/src/main/java/org/folio/mappers/FolioToRtacMapper.java
@@ -195,6 +195,7 @@ public class FolioToRtacMapper {
    * The rules for generating "volume" are as follows:
    * |data set                     |"volume"                    |
    * |-----------------------------|----------------------------|
+   * |displaySummary               |(displaySummary)            |
    * |enumeration                  |(enumeration)               |
    * |enumeration chronology       |(enumeration chronology)    |
    * |enumeration chronology volume|(enumeration chronology)    |

--- a/src/main/java/org/folio/mappers/FolioToRtacMapper.java
+++ b/src/main/java/org/folio/mappers/FolioToRtacMapper.java
@@ -212,7 +212,9 @@ public class FolioToRtacMapper {
 
     final StringJoiner sj = new StringJoiner(" ", "(", ")").setEmptyValue("");
 
-    if (isNotBlank(enumeration)) {
+    if (isNotBlank(displaySummary)) {
+      sj.add(displaySummary);
+    } else if (isNotBlank(enumeration)) {
       sj.add(enumeration);
       if (isNotBlank(chronology)) {
         sj.add(chronology);
@@ -224,8 +226,6 @@ public class FolioToRtacMapper {
       sj.add(volume);
     } else if (isNotBlank(chronology)) {
       sj.add(chronology);
-    } else if (isNotBlank(displaySummary)) {
-      sj.add(displaySummary);
     }
 
     return defaultIfEmpty(sj.toString(), null);

--- a/src/main/java/org/folio/mappers/FolioToRtacMapper.java
+++ b/src/main/java/org/folio/mappers/FolioToRtacMapper.java
@@ -195,6 +195,7 @@ public class FolioToRtacMapper {
    * The rules for generating "volume" are as follows:
    * |data set                     |"volume"                    |
    * |-----------------------------|----------------------------|
+   * |displaySummary               |(displaySummary)            |
    * |enumeration                  |(enumeration)               |
    * |enumeration chronology       |(enumeration chronology)    |
    * |enumeration chronology volume|(enumeration chronology)    |
@@ -205,9 +206,9 @@ public class FolioToRtacMapper {
    * @param item - folio inventory item
    */
   private String mapVolume(Item item) {
+    final String displaySummary = item.getDisplaySummary();
     final String enumeration = item.getEnumeration();
     final String chronology = item.getChronology();
-    final String displaySummary = item.getDisplaySummary();
     final String volume = item.getVolume();
 
     final StringJoiner sj = new StringJoiner(" ", "(", ")").setEmptyValue("");

--- a/src/test/java/org/folio/mappers/FolioToRtacMapperTest.java
+++ b/src/test/java/org/folio/mappers/FolioToRtacMapperTest.java
@@ -19,7 +19,8 @@ class FolioToRtacMapperTest {
     assertEquals(item.getId(), rtacHolding.getId());
     assertEquals(item.getCallNumber().getCallNumber(), rtacHolding.getCallNumber());
     assertEquals(item.getLocation().getLocation().getName(), rtacHolding.getLocation());
-    String expectedVolume = "(" + item.getEnumeration() + " " + item.getChronology() + ")";
+    String expectedVolume = String.format("(%s %s %s)",
+      item.getEnumeration(), item.getChronology(), item.getDisplaySummary());
     assertEquals(expectedVolume, rtacHolding.getVolume());
     assertEquals(item.getDueDate(), rtacHolding.getDueDate());
   }

--- a/src/test/java/org/folio/mappers/FolioToRtacMapperTest.java
+++ b/src/test/java/org/folio/mappers/FolioToRtacMapperTest.java
@@ -19,8 +19,22 @@ class FolioToRtacMapperTest {
     assertEquals(item.getId(), rtacHolding.getId());
     assertEquals(item.getCallNumber().getCallNumber(), rtacHolding.getCallNumber());
     assertEquals(item.getLocation().getLocation().getName(), rtacHolding.getLocation());
-    String expectedVolume = String.format("(%s %s %s)",
-        item.getEnumeration(), item.getChronology(), item.getDisplaySummary());
+    String expectedVolume = "(" + item.getEnumeration() + " " + item.getChronology() + ")";
+    assertEquals(expectedVolume, rtacHolding.getVolume());
+    assertEquals(item.getDueDate(), rtacHolding.getDueDate());
+  }
+
+  @Test
+  void testMapToRtacForAnItemWithDisplaySummary() {
+    final var folioToRtacMapper = new FolioToRtacMapper(true);
+    var inventoryHoldingsAndItems = createInventoryHoldingsAndItems().withModeOfIssuance("serial");
+    Item item = inventoryHoldingsAndItems.getItems().get(1);
+    final var rtacHoldings = folioToRtacMapper.mapToRtac(inventoryHoldingsAndItems);
+    final var rtacHolding = rtacHoldings.getHoldings().get(1);
+
+    assertEquals(item.getCallNumber().getCallNumber(), rtacHolding.getCallNumber());
+    assertEquals(item.getLocation().getLocation().getName(), rtacHolding.getLocation());
+    String expectedVolume = "(" + item.getDisplaySummary() + ")";
     assertEquals(expectedVolume, rtacHolding.getVolume());
     assertEquals(item.getDueDate(), rtacHolding.getDueDate());
   }

--- a/src/test/java/org/folio/mappers/FolioToRtacMapperTest.java
+++ b/src/test/java/org/folio/mappers/FolioToRtacMapperTest.java
@@ -20,7 +20,7 @@ class FolioToRtacMapperTest {
     assertEquals(item.getCallNumber().getCallNumber(), rtacHolding.getCallNumber());
     assertEquals(item.getLocation().getLocation().getName(), rtacHolding.getLocation());
     String expectedVolume = String.format("(%s %s %s)",
-      item.getEnumeration(), item.getChronology(), item.getDisplaySummary());
+        item.getEnumeration(), item.getChronology(), item.getDisplaySummary());
     assertEquals(expectedVolume, rtacHolding.getVolume());
     assertEquals(item.getDueDate(), rtacHolding.getDueDate());
   }

--- a/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
@@ -139,8 +139,7 @@ class RtacBatchResourceImplTest {
           RtacHolding holding =
               response.getHoldings().iterator().next().getHoldings().iterator().next();
           Item item = MockData.INSTANCE_WITH_HOLDINGS_AND_ITEMS.getItems().iterator().next();
-          String expectedVolume = String.format("(%s %s %s)",
-              item.getEnumeration(), item.getChronology(), item.getDisplaySummary());
+          String expectedVolume = "(" + item.getEnumeration() + " " + item.getChronology() + ")";
           assertEquals(expectedVolume, holding.getVolume());
           testContext.completeNow();
         });

--- a/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
@@ -265,6 +265,7 @@ class RtacBatchResourceImplTest {
           testContext.completeNow();
         });
   }
+
   @Test
   void shouldProvideHoldingsData_whenInstancesWithAndWithoutItemsRequested(
       VertxTestContext testContext) {
@@ -283,6 +284,7 @@ class RtacBatchResourceImplTest {
                 .extract()
                 .body()
                 .asString();
+
             RtacHoldingsBatch rtacResponse = MockData.stringToPojo(body, RtacHoldingsBatch.class);
             assertTrue(rtacResponse.getErrors().isEmpty());
             rtacResponse

--- a/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
@@ -265,7 +265,6 @@ class RtacBatchResourceImplTest {
           testContext.completeNow();
         });
   }
-
   @Test
   void shouldProvideHoldingsData_whenInstancesWithAndWithoutItemsRequested(
       VertxTestContext testContext) {
@@ -284,7 +283,6 @@ class RtacBatchResourceImplTest {
                 .extract()
                 .body()
                 .asString();
-
             RtacHoldingsBatch rtacResponse = MockData.stringToPojo(body, RtacHoldingsBatch.class);
             assertTrue(rtacResponse.getErrors().isEmpty());
             rtacResponse

--- a/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
@@ -140,7 +140,7 @@ class RtacBatchResourceImplTest {
               response.getHoldings().iterator().next().getHoldings().iterator().next();
           Item item = MockData.INSTANCE_WITH_HOLDINGS_AND_ITEMS.getItems().iterator().next();
           String expectedVolume = String.format("(%s %s %s)",
-            item.getEnumeration(), item.getChronology(), item.getDisplaySummary());
+              item.getEnumeration(), item.getChronology(), item.getDisplaySummary());
           assertEquals(expectedVolume, holding.getVolume());
           testContext.completeNow();
         });

--- a/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
@@ -139,7 +139,8 @@ class RtacBatchResourceImplTest {
           RtacHolding holding =
               response.getHoldings().iterator().next().getHoldings().iterator().next();
           Item item = MockData.INSTANCE_WITH_HOLDINGS_AND_ITEMS.getItems().iterator().next();
-          String expectedVolume = "(" + item.getEnumeration() + " " + item.getChronology() + ")";
+          String expectedVolume = String.format("(%s %s %s)",
+            item.getEnumeration(), item.getChronology(), item.getDisplaySummary());
           assertEquals(expectedVolume, holding.getVolume());
           testContext.completeNow();
         });
@@ -265,7 +266,7 @@ class RtacBatchResourceImplTest {
           testContext.completeNow();
         });
   }
-  
+
   @Test
   void shouldProvideHoldingsData_whenInstancesWithAndWithoutItemsRequested(
       VertxTestContext testContext) {
@@ -284,7 +285,7 @@ class RtacBatchResourceImplTest {
                 .extract()
                 .body()
                 .asString();
-          
+
             RtacHoldingsBatch rtacResponse = MockData.stringToPojo(body, RtacHoldingsBatch.class);
             assertTrue(rtacResponse.getErrors().isEmpty());
             rtacResponse

--- a/src/test/resources/mock-data/inventory-view/test_instance_with_holding_and_item.json
+++ b/src/test/resources/mock-data/inventory-view/test_instance_with_holding_and_item.json
@@ -139,6 +139,7 @@
       "notes": [],
       "chronology": "1985:July-Dec.",
       "enumeration": "v.71:no.6-2",
+      "displaySummary" : "Display summary",
       "yearCaption": [],
       "itemIdentifier": "testValue2",
       "numberOfPieces": "123",

--- a/src/test/resources/mock-data/inventory-view/test_instance_with_holding_and_item.json
+++ b/src/test/resources/mock-data/inventory-view/test_instance_with_holding_and_item.json
@@ -139,13 +139,62 @@
       "notes": [],
       "chronology": "1985:July-Dec.",
       "enumeration": "v.71:no.6-2",
-      "displaySummary" : "Display summary",
       "yearCaption": [],
       "itemIdentifier": "testValue2",
       "numberOfPieces": "123",
       "descriptionOfPieces": "testValue2",
       "numberOfMissingPieces": "2",
       "missingPieces": "testValue2",
+      "materialType": "text",
+      "electronicAccess": [],
+      "statisticalCodes": [],
+      "permanentLoanType": "Can circulate"
+    },
+    {
+      "id": "4cebe27e-c9ba-4ce8-8148-fe4d4cb40538",
+      "hrId": "22321323333",
+      "holdingsRecordId": "0c45bb50-7c9b-48b0-86eb-178a494e25fe",
+      "suppressFromDiscovery": false,
+      "status": "Available",
+      "formerIds": [
+        "ABW5508",
+        "332882"
+      ],
+      "location": {
+        "location": {
+          "name": "Main Library",
+          "campusName": "City Campus",
+          "libraryName": "Datalogisk Institut",
+          "institutionName": "Københavns Universitet"
+        },
+        "permanentLocation": {
+          "name": "testValue2",
+          "campusName": "testValue2",
+          "libraryName": "testValue2",
+          "institutionName": "testValue2"
+        },
+        "temporaryLocation": {
+          "name": "testValue2",
+          "campusName": "testValue2",
+          "libraryName": "testValue2",
+          "institutionName": "testValue2"
+        }
+      },
+      "callNumber": {
+        "callNumber": "K1 .M44"
+      },
+      "accessionNumber": "accessionNumber2",
+      "barcode": "A14813848587",
+      "copyNumber": "copyNumber2",
+      "volume": "123",
+      "notes": [],
+      "displaySummary" : "Display summary",
+      "yearCaption": [],
+      "itemIdentifier": "itemIdentifier2",
+      "numberOfPieces": "123",
+      "descriptionOfPieces": "descriptionOfPieces2",
+      "numberOfMissingPieces": "2",
+      "missingPieces": "missingPieces2",
       "materialType": "text",
       "electronicAccess": [],
       "statisticalCodes": [],


### PR DESCRIPTION
Purpose:
https://folio-org.atlassian.net/browse/MODRTAC-107

Related inventory-storage PR: https://github.com/folio-org/mod-inventory-storage/pull/985/files

How it works when displaySummary is populated:
![image](https://github.com/folio-org/mod-rtac/assets/25097693/2e3ea1d3-cfe4-4c7b-9803-00d7298d0929)

Hot it works when other field populated like enumeration, chronology:
![image](https://github.com/folio-org/mod-rtac/assets/25097693/d8b1333c-94ce-4a6f-a690-67d21a32f265)


The same is for deperecated endoint Get rtac by id
![image](https://github.com/folio-org/mod-rtac/assets/25097693/21cd614a-3d64-45fb-9a64-ed3c9129aea7)
![image](https://github.com/folio-org/mod-rtac/assets/25097693/188e5adf-201e-4386-a6b6-cb905064777c)
