### PR TITLE
Add holdingsCopyNumber and itemCopyNumber to rtac response

### DIFF
--- a/ramls/inventory-hierarchy/inventory-instance-records.json
+++ b/ramls/inventory-hierarchy/inventory-instance-records.json
@@ -407,6 +407,10 @@
             "type": "string",
             "format": "date-time",
             "description": "Due date of loan for the item"
+          },
+          "copyNumber": {
+            "description": "Copy number is the piece identifier. The copy number reflects if the library has a copy of a single-volume monograph; a copy of a multi-volume, (e.g. Copy 1, or C.7.)",
+            "type": "string"
           }
         }
       }

--- a/ramls/rtac-holding.json
+++ b/ramls/rtac-holding.json
@@ -38,6 +38,14 @@
     "permanentLoanType": {
       "type": "string",
       "description": "Name of the default loan type for a given item"
+    },
+    "holdingsCopyNumber": {
+      "type": "string",
+      "description": "Piece ID (usually barcode) for systems that do not use holdings record"
+    },
+    "itemCopyNumber": {
+      "type": "string",
+      "description": "Copy number is the piece identifier. The copy number reflects if the library has a copy of a single-volume monograph; a copy of a multi-volume, (e.g. Copy 1, or C.7.)"
     }
   },
   "required": [

--- a/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
@@ -30,6 +30,7 @@ import java.util.TimeZone;
 import java.util.stream.Stream;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Holding;
 import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.jaxrs.model.RtacHolding;
 import org.folio.rest.jaxrs.model.RtacHoldingsBatch;
@@ -141,6 +142,34 @@ class RtacBatchResourceImplTest {
           Item item = MockData.INSTANCE_WITH_HOLDINGS_AND_ITEMS.getItems().iterator().next();
           String expectedVolume = "(" + item.getEnumeration() + " " + item.getChronology() + ")";
           assertEquals(expectedVolume, holding.getVolume());
+          testContext.completeNow();
+        });
+  }
+
+  @Test
+  void shouldProperlyFormatTheHoldingValueFieldWithCopyNumbers(VertxTestContext testContext) {
+    testContext.verify(
+        () -> {
+          String validInstanceIdsJson = pojoToJson(MockData.VALID_INSTANCE_IDS_RTAC_REQUEST);
+          RequestSpecification request = createBaseRequest(validInstanceIdsJson);
+          String body =
+              request
+                  .when()
+                  .post()
+                  .then()
+                  .statusCode(200)
+                  .contentType(ContentType.JSON)
+                  .extract()
+                  .body()
+                  .asString();
+          RtacHoldingsBatch response = MockData.stringToPojo(body, RtacHoldingsBatch.class);
+          RtacHolding rtacHolding =
+              response.getHoldings().iterator().next().getHoldings().iterator().next();
+          Item item = MockData.INSTANCE_WITH_HOLDINGS_AND_ITEMS.getItems().iterator().next();
+          Holding holding =
+              MockData.INSTANCE_WITH_HOLDINGS_AND_ITEMS.getHoldings().iterator().next();
+          assertEquals(item.getCopyNumber(), rtacHolding.getItemCopyNumber());
+          assertEquals(holding.getCopyNumber(), rtacHolding.getHoldingsCopyNumber());
           testContext.completeNow();
         });
   }

--- a/src/test/resources/mock-data/inventory-view/test_instance_with_holding_and_item.json
+++ b/src/test/resources/mock-data/inventory-view/test_instance_with_holding_and_item.json
@@ -102,7 +102,7 @@
     {
       "id": "645549b1-2a73-4251-b8bb-39598f773a93",
       "hrId": "12321323121",
-      "holdingsRecordId": "0c45bb50-7c9b-48b0-86eb-178a494e25fe",
+      "holdingsRecordId": "0005bb50-7c9b-48b0-86eb-178a494e25fe",
       "suppressFromDiscovery": false,
       "status": "Available",
       "formerIds": [


### PR DESCRIPTION
## Purpose
Add holdings and itemCopyNumber to rtac response

[jira ticket](https://folio-org.atlassian.net/browse/EDGRTAC-81)

## Approach
- Change FolioRtacMapper to add holdingsCopyNumber and itemCopyNumber 