### PR TITLE
Pom.xml - added validation for descriptor files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <ramlfiles_util_path>${ramlfiles_path}/raml-util</ramlfiles_util_path>
     <raml-module-builder.version>35.2.0</raml-module-builder.version> <!-- also update vertx.version -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>
   </properties>
 
   <repositories>
@@ -555,6 +556,18 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.2</version>
+      </plugin>
+      <plugin>
+        <groupId>org.folio</groupId>
+        <artifactId>folio-module-descriptor-validator</artifactId>
+        <version>${folio-module-descriptor-validator.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
     <pluginManagement>


### PR DESCRIPTION
## Purpose 
Maven plugin for validating FOLIO module descriptors. It checks the module descriptor template placed in FOLIO modules for issues and ensures it adheres to FOLIO common approach.

- Repo for ref: https://github.com/folio-org/folio-module-descriptor-validator