### PR TITLE
Fix okapi headers

### DIFF
--- a/src/main/java/org/folio/clients/CirculationClient.java
+++ b/src/main/java/org/folio/clients/CirculationClient.java
@@ -5,6 +5,8 @@ import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
+import static org.folio.rest.RestVerticle.OKAPI_REQUESTID_HEADER;
+import static org.folio.rest.RestVerticle.OKAPI_USERID_HEADER;
 
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
@@ -138,6 +140,8 @@ class CirculationClient extends FolioClient {
     httpClientRequest
         .putHeader(OKAPI_HEADER_TOKEN, okapiToken)
         .putHeader(OKAPI_HEADER_TENANT, tenantId)
+        .putHeader(OKAPI_REQUESTID_HEADER, requestId)
+        .putHeader(OKAPI_USERID_HEADER, userId)
         .putHeader(ACCEPT, APPLICATION_JSON)
         .putHeader(CONTENT_TYPE, APPLICATION_JSON)
         .addQueryParam("limit", "10000");

--- a/src/main/java/org/folio/clients/CirculationRequestClient.java
+++ b/src/main/java/org/folio/clients/CirculationRequestClient.java
@@ -8,6 +8,8 @@ import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
+import static org.folio.rest.RestVerticle.OKAPI_REQUESTID_HEADER;
+import static org.folio.rest.RestVerticle.OKAPI_USERID_HEADER;
 import static org.folio.rest.jaxrs.model.Request.Status.OPEN_AWAITING_DELIVERY;
 import static org.folio.rest.jaxrs.model.Request.Status.OPEN_AWAITING_PICKUP;
 import static org.folio.rest.jaxrs.model.Request.Status.OPEN_IN_TRANSIT;
@@ -77,6 +79,8 @@ class CirculationRequestClient extends FolioClient {
     var httpClientRequest = webClient.getAbs(url);
     httpClientRequest.putHeader(OKAPI_HEADER_TOKEN, okapiToken)
       .putHeader(OKAPI_HEADER_TENANT, tenantId)
+        .putHeader(OKAPI_REQUESTID_HEADER, requestId)
+        .putHeader(OKAPI_USERID_HEADER, userId)
       .putHeader(ACCEPT, APPLICATION_JSON)
         .putHeader(CONTENT_TYPE, APPLICATION_JSON);
     Promise<InventoryHoldingsAndItems> promise = Promise.promise();

--- a/src/main/java/org/folio/clients/FolioClient.java
+++ b/src/main/java/org/folio/clients/FolioClient.java
@@ -1,6 +1,8 @@
 package org.folio.clients;
 
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
+import static org.folio.rest.RestVerticle.OKAPI_REQUESTID_HEADER;
+import static org.folio.rest.RestVerticle.OKAPI_USERID_HEADER;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Promise;
@@ -19,11 +21,15 @@ abstract class FolioClient {
 
   protected final String okapiUrl;
   protected final String okapiToken;
+  protected final String userId;
+  protected final String requestId;
   protected final WebClient webClient;
 
   FolioClient(Map<String, String> okapiHeaders, WebClient webClient) {
     this.okapiUrl = okapiHeaders.getOrDefault("X-Okapi-Url", "");
     this.okapiToken = okapiHeaders.getOrDefault(OKAPI_HEADER_TOKEN, "");
+    this.userId = okapiHeaders.getOrDefault(OKAPI_USERID_HEADER, "");
+    this.requestId = okapiHeaders.getOrDefault(OKAPI_REQUESTID_HEADER, "");
     this.webClient = webClient;
   }
 

--- a/src/main/java/org/folio/clients/InventoryClient.java
+++ b/src/main/java/org/folio/clients/InventoryClient.java
@@ -6,6 +6,8 @@ import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
+import static org.folio.rest.RestVerticle.OKAPI_REQUESTID_HEADER;
+import static org.folio.rest.RestVerticle.OKAPI_USERID_HEADER;
 
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -52,6 +54,8 @@ class InventoryClient extends FolioClient {
     HttpRequest<Buffer> request = webClient.requestAbs(HttpMethod.POST, inventoryUrl);
     request.putHeader(OKAPI_HEADER_TOKEN, okapiToken)
         .putHeader(OKAPI_HEADER_TENANT, tenantId)
+        .putHeader(OKAPI_REQUESTID_HEADER, requestId)
+        .putHeader(OKAPI_USERID_HEADER, userId)
         .putHeader(ACCEPT, APPLICATION_JSON)
         .putHeader(CONTENT_TYPE, APPLICATION_JSON);
 

--- a/src/main/java/org/folio/clients/PieceClient.java
+++ b/src/main/java/org/folio/clients/PieceClient.java
@@ -5,6 +5,8 @@ import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
+import static org.folio.rest.RestVerticle.OKAPI_REQUESTID_HEADER;
+import static org.folio.rest.RestVerticle.OKAPI_USERID_HEADER;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -138,6 +140,8 @@ public class PieceClient extends FolioClient {
     httpClientRequest
         .putHeader(OKAPI_HEADER_TOKEN, okapiToken)
         .putHeader(OKAPI_HEADER_TENANT, tenantId)
+        .putHeader(OKAPI_REQUESTID_HEADER, requestId)
+        .putHeader(OKAPI_USERID_HEADER, userId)
         .putHeader(ACCEPT, APPLICATION_JSON)
         .putHeader(CONTENT_TYPE, APPLICATION_JSON);
 

--- a/src/main/java/org/folio/clients/SearchClient.java
+++ b/src/main/java/org/folio/clients/SearchClient.java
@@ -5,6 +5,8 @@ import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
+import static org.folio.rest.RestVerticle.OKAPI_REQUESTID_HEADER;
+import static org.folio.rest.RestVerticle.OKAPI_USERID_HEADER;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -39,6 +41,8 @@ public class SearchClient extends FolioClient {
     httpClientRequest
         .putHeader(OKAPI_HEADER_TOKEN, okapiToken)
         .putHeader(OKAPI_HEADER_TENANT, tenantId)
+        .putHeader(OKAPI_REQUESTID_HEADER, requestId)
+        .putHeader(OKAPI_USERID_HEADER, userId)
         .putHeader(ACCEPT, APPLICATION_JSON)
         .putHeader(CONTENT_TYPE, APPLICATION_JSON)
         .addQueryParam("facet", FACET)

--- a/src/main/java/org/folio/clients/UsersClient.java
+++ b/src/main/java/org/folio/clients/UsersClient.java
@@ -5,6 +5,8 @@ import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
+import static org.folio.rest.RestVerticle.OKAPI_REQUESTID_HEADER;
+import static org.folio.rest.RestVerticle.OKAPI_USERID_HEADER;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -36,6 +38,8 @@ public class UsersClient extends FolioClient {
     httpClientRequest
         .putHeader(OKAPI_HEADER_TOKEN, okapiToken)
         .putHeader(OKAPI_HEADER_TENANT, tenantId)
+        .putHeader(OKAPI_REQUESTID_HEADER, requestId)
+        .putHeader(OKAPI_USERID_HEADER, userId)
         .putHeader(ACCEPT, APPLICATION_JSON)
         .putHeader(CONTENT_TYPE, APPLICATION_JSON);
 


### PR DESCRIPTION
"X-Okapi-User-Id" and "X-Okapi-Request-Id" are important headers and should be presented in each call.

"X-Okapi-Request-Id" can help to trace one request through multiple modules and should be copied from the incoming request and propagated to all outcoming requests

"X-Okapi-User-Id" used in many places including metadata creation, logging and tracing