### PR TITLE
MODRTAC-123: Add piece copy number to holdings

### DIFF
--- a/src/main/java/org/folio/mappers/FolioToRtacMapper.java
+++ b/src/main/java/org/folio/mappers/FolioToRtacMapper.java
@@ -86,6 +86,7 @@ public class FolioToRtacMapper {
       var receivingStatus = piece.getReceivingStatus().value();
       rtacHolding.withStatus(receivingStatus);
       rtacHolding.withVolume(mapVolume(piece));
+      rtacHolding.withHoldingsCopyNumber(piece.getCopyNumber());
       return rtacHolding;
     }).forEach(nested::add);
   }

--- a/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/RtacBatchResourceImplTest.java
@@ -240,6 +240,10 @@ class RtacBatchResourceImplTest {
               hasProperty("volume", equalTo("(testChronology3)")),
               hasProperty("volume", equalTo(""))
           )));
+          assertThat(holdings, hasItem(anyOf(
+              hasProperty("holdingsCopyNumber", equalTo("1")),
+              hasProperty("holdingsCopyNumber", equalTo("test copy number"))
+          )));
           testContext.completeNow();
         });
   }

--- a/src/test/resources/mock-data/pieces/piece_collection.json
+++ b/src/test/resources/mock-data/pieces/piece_collection.json
@@ -16,6 +16,7 @@
       "receivingStatus": "Received",
       "supplement": true,
       "isBound": true,
+      "copyNumber": "test copy number",
       "receivedDate": "2024-06-24T14:48:02.596+00:00",
       "statusUpdatedDate": "2024-06-24T14:48:02.596+00:00",
       "metadata": {


### PR DESCRIPTION
## Purpose
[MODRTAC-123](https://folio-org.atlassian.net/browse/MODRTAC-123): Show display summary info for pieces without items