### PR TITLE
fix(MODRTAC-154): Fix Vert.x race condition and Dockefile issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS Guide for `mod-rtac`
+
+## Mission and API surface
+- `mod-rtac` is a Vert.x/RMB Java 21 module that returns real-time availability for discovery clients.
+- Primary API is `POST /rtac-batch` (`ramls/rtac-batch.raml`, `src/main/java/org/folio/rest/impl/RtacBatchResourceImpl.java`).
+- Legacy `GET /rtac/{id}` is deprecated but still implemented (`ramls/rtac.raml`, `LegacyRtacGetByIdResourceImpl.java`).
+
+## Request flow (read this first)
+- Resource impls are thin: they delegate to `FolioFacade` and map failures via `ErrorMapper.handleError(...)`.
+- `FolioFacade#getItemAndHoldingInfo(RtacRequest)` orchestrates calls in this order:
+  1) inventory hierarchy, 2) loans, 3) requests, 4) pieces, 5) mapping to RTAC DTOs.
+- Consortia-aware behavior:
+  - Detect central tenant via `/user-tenants` (`UsersClient`).
+  - For central tenants, find member tenants per instance via `/search/instances/facets` facet `holdings.tenantId` (`SearchClient`).
+  - Merge per-tenant holdings/items/pieces by `instanceId` in `FolioFacade#mergeTenantData`.
+
+## Integration points and downstream contracts
+- Inventory: `POST /inventory-hierarchy/items-and-holdings` with `skipSuppressedFromDiscoveryRecords=true` (`InventoryClient`).
+- Loans: `GET /loan-storage/loans` with CQL batches of 50 item IDs and `status.name==open` (`CirculationClient`).
+- Requests: `GET /circulation/requests` and count only open statuses (`CirculationRequestClient`).
+- Pieces: `GET /orders/pieces` filtered by `displayToPublic=true and displayOnHolding=true` (`PieceClient`).
+- Settings: `GET /settings/entries` with `(scope==mod-rtac and key==LOAN_TENANT)` (`SettingsClient`, README settings section).
+
+## Project-specific behavior to preserve
+- Periodical logic is domain-critical: treat instances as periodicals when mode is `serial` or nature of content includes `journal`/`newspaper` (`FolioToRtacMapper`).
+- `fullPeriodicals=false` returns holding-level data for periodicals; `true` includes full item mapping.
+- Inventory hierarchy can return concatenated JSON objects (not a JSON array); parsing uses Vert.x `JsonParser.objectValueMode()` (`InventoryClientTests` documents this).
+- Downstream `400` errors are intentionally exposed as `500` to RTAC clients (`ErrorMapper`, `RtacBatchResourceImplTest#rtacFailureCodes`).
+- `LOAN_TENANT` setting lookup is cached for 10 minutes in Vert.x context cache `rtac-cache` (`Init`, `CirculationClient`).
+
+## Build, test, and local run workflows
+- Build + tests: `mvn clean verify`
+- Fast test run: `mvn test`
+- Run module locally after packaging: `java -Dport=8081 -jar target/mod-rtac-fat.jar -Dhttp.port=8081` (from `descriptors/DeploymentDescriptor-template.json`).
+- Docker image expects fat jar in `target/*.jar` and exposes `8081` (`Dockerfile`).
+
+## Code conventions in this repo
+- Implement generated RMB interfaces under `src/main/java/org/folio/rest/impl`; RAML drives interfaces via `domain-models-maven-plugin`.
+- Prefer async composition with Vert.x `Future`/`Promise`; on enrichment failures, many clients log warning and return partial inventory data instead of failing whole request.
+- Keep headers tenant-aware (`X-Okapi-Tenant`, `X-Okapi-Token`, `X-Okapi-Url`) and use case-insensitive maps in tests.
+- Formatting/lint baseline: `.editorconfig` (2-space indent, 100-char max), Google Checkstyle via Maven validate phase.
+
+## Change checklist anchors
+- If API, permissions, or dependencies change, update `ramls/*` and `descriptors/ModuleDescriptor-template.json` together.
+- Add/update tests in both styles used here: module-level integration (`RtacBatchResourceImplTest` + `MockServer`) and client-level WireMock tests (`src/test/java/org/folio/clients/*Tests.java`).
+- Update `NEWS.md` for user-visible behavior changes (see PR template checklist).
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ USER root
 RUN apk upgrade --no-cache
 USER folio
 
-ENV VERTICLE_FILE mod-rtac-fat.jar
+ENV VERTICLE_FILE=mod-rtac-fat.jar
 
 # Set the location of the verticles
-ENV VERTICLE_HOME /usr/verticles
+ENV VERTICLE_HOME=/usr/verticles
 
 # Copy your fat jar to the container
 COPY target/${VERTICLE_FILE} ${VERTICLE_HOME}/${VERTICLE_FILE}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# https://github.com/folio-org/folio-tools/tree/master/folio-java-docker/openjdk17
 FROM folioci/alpine-jre-openjdk21:latest
 
 # Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
@@ -6,8 +5,13 @@ USER root
 RUN apk upgrade --no-cache
 USER folio
 
-# Copy your fat jar to the container; if multiple *.jar files exist the .dockerignore file excludes others
-COPY target/*.jar ${JAVA_APP_DIR}
+ENV VERTICLE_FILE mod-rtac-fat.jar
+
+# Set the location of the verticles
+ENV VERTICLE_HOME /usr/verticles
+
+# Copy your fat jar to the container
+COPY target/${VERTICLE_FILE} ${VERTICLE_HOME}/${VERTICLE_FILE}
 
 # Expose this port locally in the container.
 EXPOSE 8081

--- a/pom.xml
+++ b/pom.xml
@@ -499,6 +499,7 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
                   <file>log4j2.xml</file>
                 </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
               <filters>
                 <filter>


### PR DESCRIPTION
### Purpose
Resolves a race condition by ensuring FolioLogging properties are correctly handled within ContextLocal and optimizes the Dockerfile to selectively copy only the required fat jar to its designated folder, which avoids Rancher jar scanning issues.

### Approach
- Update pom.xml to add additional transformation section
- Update Dockerfile  to copy only a certain fat jar file to a necessary folder

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODRTAC-154

### Screenshots (if applicable)
<img width="1065" height="942" alt="image" src="https://github.com/user-attachments/assets/96f66522-4b76-4a95-8bb7-d45d54b80c98" />

